### PR TITLE
Removed multi-bidfloor functionality

### DIFF
--- a/core/auction.go
+++ b/core/auction.go
@@ -50,3 +50,13 @@ func RunAuctionSingleBidFloor(
 		FloorRejectedBidIDs: rejectedBids,
 	}
 }
+
+// TODO(kestutisg): remove this function and rename RunAuctionSingleBidFloor to RunAuction
+// once auction-server switches to calling RunAuction
+func RunAuction(
+	bids []CoreBid,
+	adjustmentFactors map[string]float64,
+	bidFloor float64,
+) *AuctionResult {
+	return RunAuctionSingleBidFloor(bids, adjustmentFactors, bidFloor)
+}

--- a/core/auction.go
+++ b/core/auction.go
@@ -13,57 +13,6 @@ package core
 //
 // Processing flow:
 //  1. Apply bid adjustment factors (multipliers per bidder)
-//  2. Enforce per-bidder floor prices
-//  3. Rank eligible bids by price
-//  4. Extract winner and runner-up from ranking
-func RunAuction(
-	bids []CoreBid,
-	adjustmentFactors map[string]float64,
-	bidFloors map[string]float64,
-) *AuctionResult {
-	// Step 1: Apply bid adjustment factors
-	// Use conversion rate of 1.0 (no currency conversion in unified logic)
-	adjustedBids := bids
-	if len(adjustmentFactors) > 0 {
-		adjustedBids = ApplyBidAdjustmentFactors(bids, adjustmentFactors, 1.0)
-	}
-
-	// Step 2: Enforce per-bidder floor prices
-	eligibleBids, rejectedBids := EnforceBidFloors(adjustedBids, bidFloors)
-
-	// Step 3: Rank eligible bids
-	ranking := RankCoreBids(eligibleBids)
-
-	// Step 4: Extract winner and runner-up from ranking
-	var winner, runnerUp *CoreBid
-	if len(ranking.SortedBidders) > 0 {
-		winner = ranking.HighestBids[ranking.SortedBidders[0]]
-	}
-	if len(ranking.SortedBidders) > 1 {
-		runnerUp = ranking.HighestBids[ranking.SortedBidders[1]]
-	}
-
-	return &AuctionResult{
-		Winner:              winner,
-		RunnerUp:            runnerUp,
-		EligibleBids:        eligibleBids,
-		FloorRejectedBidIDs: rejectedBids,
-	}
-}
-
-// RunAuction executes the core auction logic: adjustment → floor enforcement → ranking.
-// This function provides a unified auction implementation used by both TEE and local processing.
-//
-// Parameters:
-//   - bids: Input bids (should already be decrypted if from TEE)
-//   - adjustmentFactors: Per-bidder adjustment multipliers
-//   - bidFloors: Per-bidder floor prices
-//
-// Returns:
-//   - AuctionResult containing winner, runner-up, eligible bids, rejected bids, and full ranking
-//
-// Processing flow:
-//  1. Apply bid adjustment factors (multipliers per bidder)
 //  2. Enforce floor price
 //  3. Rank eligible bids by price
 //  4. Extract winner and runner-up from ranking

--- a/core/floorenforcement.go
+++ b/core/floorenforcement.go
@@ -15,32 +15,6 @@ func BidMeetsFloor(bidPrice, floorPrice float64) bool {
 	return bidPriceDecimal.GreaterThanOrEqual(floorDecimal)
 }
 
-// EnforceBidFloors filters bids based on per-bidder floor prices.
-// Returns eligible bids and IDs of rejected bids.
-// If a bidder has no floor in the map, their bids pass without enforcement.
-func EnforceBidFloors(bids []CoreBid, floors map[string]float64) (eligible []CoreBid, rejectedBidIDs []string) {
-	eligibleBids := make([]CoreBid, 0, len(bids))
-	rejectedIDs := make([]string, 0)
-
-	for _, bid := range bids {
-		floor, hasFloor := floors[bid.Bidder]
-
-		// If no floor for this bidder, bid passes
-		if !hasFloor {
-			eligibleBids = append(eligibleBids, bid)
-			continue
-		}
-
-		if BidMeetsFloor(bid.Price, floor) {
-			eligibleBids = append(eligibleBids, bid)
-		} else {
-			rejectedIDs = append(rejectedIDs, bid.ID)
-		}
-	}
-
-	return eligibleBids, rejectedIDs
-}
-
 // EnforceBidFloors filters bids based on floor price.
 // Returns eligible bids and IDs of rejected bids.
 // If a bidder has no floor in the map, their bids pass without enforcement.

--- a/enclave/proofs.go
+++ b/enclave/proofs.go
@@ -142,7 +142,6 @@ func GenerateAttestation(
 		RequestHash:            requestHash,
 		AdjustmentFactorsHash:  adjustmentFactorsHash,
 		BidFloor:               req.BidFloor,
-		BidFloors:              req.BidFloors, // TODO(kestutisg): remove to fully transition to single bid floor
 		BidHashNonce:           bidHashNonce,
 		Winner:                 stripBidderName(winner),
 		RunnerUp:               stripBidderName(runnerUp),

--- a/enclaveapi/types.go
+++ b/enclaveapi/types.go
@@ -99,8 +99,7 @@ type AttestationUserData struct {
 	BidHashes              []string              `json:"bid_hashes"`
 	RequestHash            string                `json:"request_hash"`
 	AdjustmentFactorsHash  string                `json:"adjustment_factors_hash"`
-	BidFloor               float64               `json:"bid_floor,omitempty"`
-	BidFloors              map[string]float64    `json:"bid_floors,omitempty"` // TODO(kestutisg): remove to fully transition to single bid floor
+	BidFloor               float64               `json:"bid_floor"`
 	BidHashNonce           string                `json:"bid_hash_nonce"`
 	Winner                 *CoreBidWithoutBidder `json:"winner,omitempty"`
 	RunnerUp               *CoreBidWithoutBidder `json:"runner_up,omitempty"`
@@ -135,8 +134,7 @@ type EnclaveAuctionRequest struct {
 	RoundID           int                `json:"round_id"`
 	Bids              []EncryptedCoreBid `json:"bids"`
 	AdjustmentFactors map[string]float64 `json:"adjustment_factors"`
-	BidFloor          float64            `json:"bid_floor,omitempty"`
-	BidFloors         map[string]float64 `json:"bid_floors,omitempty"` // TODO(kestutisg): remove to fully transition to single bid floor
+	BidFloor          float64            `json:"bid_floor"`
 	Timestamp         time.Time          `json:"timestamp"`
 }
 


### PR DESCRIPTION
This is second part (first part was #1 ) of moving from per bidder bidfloor to single bidfloor. 

PR should be merged and deployed ONLY after https://github.com/cloudx-io/cloudexchange.ssp/pull/987 is deployed to prod.