### PR TITLE
build docker container image via Github Actions

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,75 @@
+name: docker
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+jobs:
+  enclave:
+    needs: [test, lint]
+    permissions:
+      id-token: write # for AWS OIDC authentication
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.25.1"
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/github-actions-ecr-push
+          aws-region: us-east-1
+      - name: Login to Amazon ECR
+        uses: aws-actions/amazon-ecr-login@v2
+      - name: go build bin/enclave-linux-amd64
+        run: |
+          CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -ldflags '-extldflags "-static"' -tags netgo -o ./bin/tee-auction-enclave ./enclave
+      - name: docker set build tag env vars
+        run: |
+          VERSION="0.0.0"
+          SHA="$(git rev-parse --short HEAD || echo 'unknown')"
+          DIRTY="$(git diff --no-ext-diff --quiet --exit-code HEAD || echo '.dirty')"
+          COMMIT="${SHA}${DIRTY}"
+          echo "CLOUDX_VERSION=${VERSION}" >> $GITHUB_ENV
+          echo "CLOUDX_COMMIT=${COMMIT}" >> $GITHUB_ENV
+      - name: docker set metadata
+        id: dockermetadata
+        # https://github.com/docker/metadata-action
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.us-east-1.amazonaws.com/cloudx-io/openauction/enclave
+          labels: |
+            org.opencontainers.image.title=cloudx-io/openauction/enclave
+            org.opencontainers.image.description=CloudX Nitro Enclave for secure auction processing
+            org.opencontainers.image.vendor=cloudx.io
+            org.opencontainers.image.source=https://github.com/cloudx-io/openauction
+          tags: |
+            # short sha of the commit
+            type=sha,prefix=,suffix=,format=short
+            # long sha of the commit
+            type=sha,prefix=,suffix=,format=long
+            # our version tag, like "0.0.0-commit.ABCDEF01"
+            type=raw,value=${{ env.CLOUDX_VERSION }}-commit.${{ env.CLOUDX_COMMIT }}
+            # "latest"
+            type=raw,value=latest
+      - uses: docker/setup-buildx-action@v3.11.1
+        with:
+          platforms: linux/amd64
+      - uses: docker/build-push-action@v6.18.0
+        with:
+          context: .
+          file: enclave/Dockerfile
+          platforms: linux/amd64
+          # This workflow runs when you update a PR and also when you merge a
+          # PR into `main`. This conditional makes it so that the image is only
+          # pushed when the PR is merged, not when you push new commits to a
+          # PR.
+          push: ${{ github.event_name != 'pull_request' }}
+          sbom: true
+          provenance: mode=max
+          tags: ${{ steps.dockermetadata.outputs.tags }}
+          labels: ${{ steps.dockermetadata.outputs.labels }}
+          build-args: |
+            ENCLAVE_MAX_WORKERS=50

--- a/enclave/Dockerfile
+++ b/enclave/Dockerfile
@@ -1,35 +1,18 @@
-FROM golang:1.25-alpine AS builder
-
-RUN apk add --no-cache git ca-certificates
-
-WORKDIR /app
-
-COPY go.mod go.sum ./
-
-RUN go mod download
-
-COPY core/ ./core/
-COPY enclaveapi/ ./enclaveapi/
-
-COPY enclave/*.go ./enclave/
-
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build \
-    -a -ldflags '-extldflags "-static"' \
-    -tags netgo \
-    -o tee-auction-enclave \
-    ./enclave
-
 FROM amazonlinux:2023
 
 ARG ENCLAVE_MAX_WORKERS=50
 ENV ENCLAVE_MAX_WORKERS=${ENCLAVE_MAX_WORKERS}
 
 RUN dnf update -y && \
-    dnf install -y ca-certificates && \
+    dnf install -y ca-certificates nmap-ncat && \
     dnf clean all && \
     rm -rf /var/cache/dnf
 
-COPY --from=builder /app/tee-auction-enclave /usr/local/bin/tee-auction-enclave
+# This Dockerfile assumes that you have already built a binary on the host
+# machine using the GitHub Actions workflow, and we just copy it into the
+# container. This makes builds faster and more cacheable than a multi-stage
+# build-in-Docker approach.
+COPY ./bin/tee-auction-enclave /usr/local/bin/tee-auction-enclave
 
 RUN chmod +x /usr/local/bin/tee-auction-enclave
 


### PR DESCRIPTION
## Summary

Add GitHub Actions CI/CD workflow to automatically build and push enclave Docker images to ECR. This enables automated deployment of enclave updates whenever changes are merged to main, matching the pattern used by cloudexchange.ssp services.

### Changes

- Add `.github/workflows/docker.yml` with enclave build job that depends on existing test/lint jobs
- Build enclave binary with static linking before Docker build for faster, more cacheable builds
- Push images to ECR repo
- Generate multiple tags: short SHA, long SHA, versioned tag (`0.0.0-commit.ABCDEF01`), and `latest`
- Use AWS OIDC authentication (no long-lived credentials)
- Simplify `enclave/Dockerfile` to single-stage build that copies pre-built binary (removes redundant compilation)
- Only push images on merge to main, not on PR commits