### PR TITLE
return auction attestation in COSE format

### DIFF
--- a/enclave/auction.go
+++ b/enclave/auction.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"log"
@@ -57,7 +58,7 @@ func ProcessAuction(attester EnclaveAttester, req enclaveapi.EnclaveAuctionReque
 	winner := auctionResult.Winner
 	runnerUp := auctionResult.RunnerUp
 
-	teeData, err := GenerateTEEProofs(attester, req, unencryptedBids, winner, runnerUp)
+	teeData, attestationCOSE, err := GenerateTEEProofs(attester, req, unencryptedBids, winner, runnerUp)
 	processingTime := time.Since(startTime).Milliseconds()
 
 	log.Printf("INFO: Auction complete: winner=%s (%.2f), runner-up=%s (%.2f), processing=%dms",
@@ -77,13 +78,14 @@ func ProcessAuction(attester EnclaveAttester, req enclaveapi.EnclaveAuctionReque
 	}
 
 	return enclaveapi.EnclaveAuctionResponse{
-		Type:                "auction_response",
-		Success:             true,
-		Message:             fmt.Sprintf("Processed %d bids in enclave", len(req.Bids)),
-		AttestationDoc:      teeData,
-		ExcludedBids:        excludedBids,
-		FloorRejectedBidIDs: floorRejectedBidIDs,
-		ProcessingTime:      processingTime,
+		Type:                  "auction_response",
+		Success:               true,
+		Message:               fmt.Sprintf("Processed %d bids in enclave", len(req.Bids)),
+		AttestationDoc:        teeData,
+		AttestationCOSEBase64: base64.StdEncoding.EncodeToString(attestationCOSE),
+		ExcludedBids:          excludedBids,
+		FloorRejectedBidIDs:   floorRejectedBidIDs,
+		ProcessingTime:        processingTime,
 	}
 }
 

--- a/enclave/proofs_test.go
+++ b/enclave/proofs_test.go
@@ -137,12 +137,13 @@ func TestGenerateAttestation(t *testing.T) {
 
 	// Test with nil enclave handle (error case)
 	bidHashes := []string{"hash1", "hash2"}
-	attestationDoc, err := GenerateAttestation(nil, req, bidHashes, "test_request_hash", "test_adj_hash",
+	attestationDoc, coseBytes, err := GenerateAttestation(nil, req, bidHashes, "test_request_hash", "test_adj_hash",
 		"test_bid_nonce", "test_req_nonce", "test_adj_nonce", winner, runnerUp)
 
 	// Should fail with nil enclave handle
 	check.Error(t, err)
 	check.Nil(t, attestationDoc)
+	check.Nil(t, coseBytes)
 	check.True(t, strings.Contains(err.Error(), "enclave attester is nil"))
 }
 
@@ -167,12 +168,14 @@ func TestGenerateAttestationWithMock(t *testing.T) {
 	bidHash := generateBidHash("bid1", 2.50, bidHashNonce)
 
 	// Test successful attestation generation with mock
-	attestationDoc, err := GenerateAttestation(mockEnclave, req, []string{bidHash}, "test_request_hash", "test_adj_hash",
+	attestationDoc, coseBytes, err := GenerateAttestation(mockEnclave, req, []string{bidHash}, "test_request_hash", "test_adj_hash",
 		bidHashNonce, "test_req_nonce", "test_adj_nonce", winner, nil)
 
 	// Should succeed with mock enclave
 	check.NoError(t, err)
 	check.NotNil(t, attestationDoc)
+	check.NotNil(t, coseBytes)
+	check.True(t, len(coseBytes) > 0)
 	check.Equal(t, "test-enclave-12345", attestationDoc.ModuleID)
 	check.Equal(t, "SHA384", attestationDoc.DigestAlgorithm)
 	check.NotNil(t, attestationDoc.UserData)
@@ -240,12 +243,14 @@ func TestGenerateAttestationWithEncryptedBids(t *testing.T) {
 	bidHashes := []string{hash2, hash3}
 
 	// Test successful attestation generation with encrypted bids
-	attestationDoc, err := GenerateAttestation(mockEnclave, req, bidHashes, "test_request_hash", "test_adj_hash",
+	attestationDoc, coseBytes, err := GenerateAttestation(mockEnclave, req, bidHashes, "test_request_hash", "test_adj_hash",
 		bidHashNonce, "test_req_nonce", "test_adj_nonce", winner, runnerUp)
 
 	// Should succeed with mock enclave
 	check.NoError(t, err)
 	check.NotNil(t, attestationDoc)
+	check.NotNil(t, coseBytes)
+	check.True(t, len(coseBytes) > 0)
 	check.Equal(t, "test-enclave-12345", attestationDoc.ModuleID)
 	check.Equal(t, "SHA384", attestationDoc.DigestAlgorithm)
 
@@ -508,12 +513,14 @@ func TestGenerateAttestationWithMixedBidTypes(t *testing.T) {
 	bidHashes := []string{hashU1, hashE1, hashU2, hashE2, hashU3}
 
 	// Generate attestation for mixed bid scenario
-	attestationDoc, err := GenerateAttestation(mockEnclave, req, bidHashes, "mixed_request_hash", "mixed_adj_hash",
+	attestationDoc, coseBytes, err := GenerateAttestation(mockEnclave, req, bidHashes, "mixed_request_hash", "mixed_adj_hash",
 		bidHashNonce, "mixed_req_nonce", "mixed_adj_nonce", winner, runnerUp)
 
 	// Verify successful attestation generation
 	check.NoError(t, err)
 	check.NotNil(t, attestationDoc)
+	check.NotNil(t, coseBytes)
+	check.True(t, len(coseBytes) > 0)
 	check.Equal(t, "test-enclave-12345", attestationDoc.ModuleID)
 
 	// Verify user data reflects the mixed bid scenario

--- a/enclaveapi/types.go
+++ b/enclaveapi/types.go
@@ -140,13 +140,14 @@ type EnclaveAuctionRequest struct {
 
 // EnclaveAuctionResponse represents the response from TEE enclaves after auction processing
 type EnclaveAuctionResponse struct {
-	Type                string                 `json:"type"`
-	Success             bool                   `json:"success"`
-	Message             string                 `json:"message"`
-	AttestationDoc      *AuctionAttestationDoc `json:"attestation_document,omitempty"`
-	ExcludedBids        []core.ExcludedBid     `json:"excluded_bids,omitempty"`          // Decryption failures, validation errors
-	FloorRejectedBidIDs []string               `json:"floor_rejected_bid_ids,omitempty"` // Bid IDs that were below floor
-	ProcessingTime      int64                  `json:"processing_time_ms"`
+	Type                  string                 `json:"type"`
+	Success               bool                   `json:"success"`
+	Message               string                 `json:"message"`
+	AttestationDoc        *AuctionAttestationDoc `json:"attestation_document,omitempty"`    // Deprecated: Use attestation_cose_base64
+	AttestationCOSEBase64 string                 `json:"attestation_cose_base64,omitempty"` // Base64-encoded COSE_Sign1 attestation
+	ExcludedBids          []core.ExcludedBid     `json:"excluded_bids,omitempty"`           // Decryption failures, validation errors
+	FloorRejectedBidIDs   []string               `json:"floor_rejected_bid_ids,omitempty"`  // Bid IDs that were below floor
+	ProcessingTime        int64                  `json:"processing_time_ms"`
 }
 
 // KeyResponse represents the response from a key request to the TEE enclave


### PR DESCRIPTION
## Summary

Adds COSE-based attestation support to auction responses, bringing auction attestation in line with the existing key attestation pattern. Auction responses now include both the deprecated JSON attestation format and the new COSE format for bidder validation.

## Motivation

Currently, openauction provides two different attestation formats:
- **Key attestation**: Returns both `KeyAttestation` (JSON, deprecated) and `AttestationCOSEBase64` (COSE format)
- **Auction attestation**: Only returns `AttestationDoc` (JSON format)

Attestations in COSE format are necessary to perform validation.

## Changes

### API Changes

- Added `AttestationCOSEBase64` field to `EnclaveAuctionResponse`
- Marked existing `AttestationDoc` field as deprecated

### Function Signature Updates

- Updated `GenerateAttestation()` to return `(*AuctionAttestationDoc, []byte, error)`
  - Now returns both the parsed attestation document and raw COSE bytes
  - Mirrors the pattern used by `GenerateKeyAttestation()`
- Updated `GenerateTEEProofs()` to return `(*AuctionAttestationDoc, []byte, error)`
  - Passes through COSE bytes from `GenerateAttestation()`

- Updated `ProcessAuction()` to capture and encode COSE bytes
- Populates `AttestationCOSEBase64` in `EnclaveAuctionResponse`

## Example Response

```json
{
  "type": "auction_response",
  "success": true,
  "message": "Processed 3 bids in enclave",
  "attestation_document": { ... },  // Deprecated
  "attestation_cose_base64": "hEShATgioFkE2KRZBMUwggTBMII...",  // New
  "excluded_bids": [],
  "floor_rejected_bid_ids": [],
  "processing_time_ms": 15
}
```