### PR TITLE
use type definitions to represent different attestation encodings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# compiled commands
+key-validator

--- a/enclave/auction.go
+++ b/enclave/auction.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"log"
@@ -58,7 +57,7 @@ func ProcessAuction(attester EnclaveAttester, req enclaveapi.EnclaveAuctionReque
 	winner := auctionResult.Winner
 	runnerUp := auctionResult.RunnerUp
 
-	teeData, attestationCOSE, err := GenerateTEEProofs(attester, req, unencryptedBids, winner, runnerUp)
+	teeData, coseAttestation, err := GenerateTEEProofs(attester, req, unencryptedBids, winner, runnerUp)
 	processingTime := time.Since(startTime).Milliseconds()
 
 	log.Printf("INFO: Auction complete: winner=%s (%.2f), runner-up=%s (%.2f), processing=%dms",
@@ -82,7 +81,7 @@ func ProcessAuction(attester EnclaveAttester, req enclaveapi.EnclaveAuctionReque
 		Success:               true,
 		Message:               fmt.Sprintf("Processed %d bids in enclave", len(req.Bids)),
 		AttestationDoc:        teeData,
-		AttestationCOSEBase64: base64.StdEncoding.EncodeToString(attestationCOSE),
+		AttestationCOSEBase64: coseAttestation.EncodeBase64(),
 		ExcludedBids:          excludedBids,
 		FloorRejectedBidIDs:   floorRejectedBidIDs,
 		ProcessingTime:        processingTime,

--- a/enclave/keymanager.go
+++ b/enclave/keymanager.go
@@ -3,7 +3,6 @@ package main
 import (
 	"crypto/rsa"
 	"crypto/x509"
-	"encoding/base64"
 	"encoding/pem"
 	"fmt"
 
@@ -56,18 +55,15 @@ func HandleKeyRequest(attester EnclaveAttester, keyManager *KeyManager, tokenMan
 
 	auctionToken := tokenManager.GenerateToken()
 
-	keyAttestation, attestationCBOR, err := GenerateKeyAttestation(attester, keyManager.PublicKey, auctionToken)
+	keyAttestation, coseAttestation, err := GenerateKeyAttestation(attester, keyManager.PublicKey, auctionToken)
 	if err != nil {
 		return nil, fmt.Errorf("failed to generate key attestation: %w", err)
 	}
-
-	// Encode COSE bytes to base64 for JSON transport
-	attestationCOSEBase64 := base64.StdEncoding.EncodeToString(attestationCBOR)
 
 	return &enclaveapi.KeyResponse{
 		Type:                  "key_response",
 		PublicKey:             publicKeyPEM,
 		KeyAttestation:        keyAttestation,
-		AttestationCOSEBase64: attestationCOSEBase64,
+		AttestationCOSEBase64: coseAttestation.EncodeBase64(),
 	}, nil
 }

--- a/enclave/proofs.go
+++ b/enclave/proofs.go
@@ -27,7 +27,7 @@ type EnclaveAttester interface {
 	Attest(options enclave.AttestationOptions) ([]byte, error)
 }
 
-func GenerateTEEProofs(attester EnclaveAttester, req enclaveapi.EnclaveAuctionRequest, unencryptedBids []core.CoreBid, winner, runnerUp *core.CoreBid) (*enclaveapi.AuctionAttestationDoc, []byte, error) {
+func GenerateTEEProofs(attester EnclaveAttester, req enclaveapi.EnclaveAuctionRequest, unencryptedBids []core.CoreBid, winner, runnerUp *core.CoreBid) (*enclaveapi.AuctionAttestationDoc, enclaveapi.AttestationCOSE, error) {
 	bidHashNonce, err := generateNonce()
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to generate bid hash nonce: %w", err)
@@ -132,7 +132,7 @@ func GenerateAttestation(
 	adjustmentFactorsNonce string,
 	winner *core.CoreBid,
 	runnerUp *core.CoreBid,
-) (*enclaveapi.AuctionAttestationDoc, []byte, error) {
+) (*enclaveapi.AuctionAttestationDoc, enclaveapi.AttestationCOSE, error) {
 	now := time.Now()
 
 	// Create the user data that will be embedded in the attestation
@@ -183,7 +183,7 @@ func GenerateAttestation(
 	}
 
 	// Return both the parsed attestation and the raw COSE bytes
-	return attestationDoc, attestationCBOR, nil
+	return attestationDoc, enclaveapi.AttestationCOSE(attestationCBOR), nil
 }
 
 // Deprecated: can delete this once we've migrated to the new attestation format
@@ -259,7 +259,7 @@ func publicKeyToPEM(publicKey *rsa.PublicKey) (string, error) {
 
 // GenerateKeyAttestation generates an attestation document for E2EE public keys
 // Returns the parsed attestation and the raw COSE bytes
-func GenerateKeyAttestation(attester EnclaveAttester, publicKey *rsa.PublicKey, auctionToken string) (*enclaveapi.KeyAttestationDoc, []byte, error) {
+func GenerateKeyAttestation(attester EnclaveAttester, publicKey *rsa.PublicKey, auctionToken string) (*enclaveapi.KeyAttestationDoc, enclaveapi.AttestationCOSE, error) {
 	if attester == nil {
 		return nil, nil, fmt.Errorf("enclave attester is nil")
 	}
@@ -303,7 +303,7 @@ func GenerateKeyAttestation(attester EnclaveAttester, publicKey *rsa.PublicKey, 
 	}
 
 	// Return both the parsed attestation and the raw COSE bytes
-	return keyAttestation, attestationCBOR, nil
+	return keyAttestation, enclaveapi.AttestationCOSE(attestationCBOR), nil
 }
 
 // ParseKeyAttestation parses CBOR attestation specifically for key attestation

--- a/enclaveapi/types.go
+++ b/enclaveapi/types.go
@@ -164,6 +164,13 @@ type KeyResponse struct {
 	AttestationCOSEBase64 AttestationCOSEBase64 `json:"attestation_cose_base64,omitempty"` // Base64-encoded COSE_Sign1 attestation
 }
 
+// KeyWithAttestation represents a public key with its TEE attestation
+// Used in bid requests and key validation tools
+type KeyWithAttestation struct {
+	PublicKey   string              `json:"public_key"`                             // PEM-encoded RSA public key
+	Attestation AttestationCOSEGzip `json:"attestation_cose_gzip_base64,omitempty"` // Gzipped and base64-encoded COSE_Sign1 attestation
+}
+
 // KeyAttestationUserData represents the key-specific data embedded in key attestation
 type KeyAttestationUserData struct {
 	KeyAlgorithm string `json:"key_algorithm"` // e.g., "RSA-2048"

--- a/enclaveapi/types.go
+++ b/enclaveapi/types.go
@@ -1,9 +1,14 @@
 package enclaveapi
 
 import (
+	"bytes"
+	"compress/gzip"
 	"encoding/base64"
 	"encoding/json"
+	"fmt"
+	"io"
 	"net/url"
+	"strings"
 	"time"
 
 	"github.com/cloudx-io/openauction/core"
@@ -144,7 +149,7 @@ type EnclaveAuctionResponse struct {
 	Success               bool                   `json:"success"`
 	Message               string                 `json:"message"`
 	AttestationDoc        *AuctionAttestationDoc `json:"attestation_document,omitempty"`    // Deprecated: Use attestation_cose_base64
-	AttestationCOSEBase64 string                 `json:"attestation_cose_base64,omitempty"` // Base64-encoded COSE_Sign1 attestation
+	AttestationCOSEBase64 AttestationCOSEBase64  `json:"attestation_cose_base64,omitempty"` // Base64-encoded COSE_Sign1 attestation
 	ExcludedBids          []core.ExcludedBid     `json:"excluded_bids,omitempty"`           // Decryption failures, validation errors
 	FloorRejectedBidIDs   []string               `json:"floor_rejected_bid_ids,omitempty"`  // Bid IDs that were below floor
 	ProcessingTime        int64                  `json:"processing_time_ms"`
@@ -152,11 +157,11 @@ type EnclaveAuctionResponse struct {
 
 // KeyResponse represents the response from a key request to the TEE enclave
 type KeyResponse struct {
-	Type                  string             `json:"type"`
-	PublicKey             string             `json:"public_key"`                        // PEM format
-	TEEInstanceIP         string             `json:"tee_instance_ip,omitempty"`         // Injected by HTTP bridge
-	KeyAttestation        *KeyAttestationDoc `json:"key_attestation"`                   // Deprecated: Use attestation_cose_base64 instead
-	AttestationCOSEBase64 string             `json:"attestation_cose_base64,omitempty"` // Base64-encoded COSE_Sign1 attestation
+	Type                  string                `json:"type"`
+	PublicKey             string                `json:"public_key"`                        // PEM format
+	TEEInstanceIP         string                `json:"tee_instance_ip,omitempty"`         // Injected by HTTP bridge
+	KeyAttestation        *KeyAttestationDoc    `json:"key_attestation"`                   // Deprecated: Use attestation_cose_base64 instead
+	AttestationCOSEBase64 AttestationCOSEBase64 `json:"attestation_cose_base64,omitempty"` // Base64-encoded COSE_Sign1 attestation
 }
 
 // KeyAttestationUserData represents the key-specific data embedded in key attestation
@@ -164,4 +169,129 @@ type KeyAttestationUserData struct {
 	KeyAlgorithm string `json:"key_algorithm"` // e.g., "RSA-2048"
 	PublicKey    string `json:"public_key"`    // PEM-encoded public key
 	AuctionToken string `json:"auction_token"` // Single-use token for bid replay protection
+}
+
+// AttestationCOSE represents raw COSE_Sign1 bytes from AWS Nitro Enclaves
+type AttestationCOSE []byte
+
+// EncodeBase64 converts COSE bytes to standard base64 string
+func (a AttestationCOSE) EncodeBase64() AttestationCOSEBase64 {
+	return AttestationCOSEBase64(base64.StdEncoding.EncodeToString(a))
+}
+
+// EncodeURLSafe converts COSE bytes to URL-safe base64 string (no padding)
+func (a AttestationCOSE) EncodeURLSafe() AttestationCOSEURLBase64 {
+	encoded := base64.URLEncoding.EncodeToString(a)
+	// Remove padding for URL safety
+	encoded = strings.TrimRight(encoded, "=")
+	return AttestationCOSEURLBase64(encoded)
+}
+
+// CompressGzip compresses COSE bytes with GZIP and encodes as base64url (no padding)
+// Used for URL-safe transmission in win/loss notifications and bid responses
+func (a AttestationCOSE) CompressGzip() (AttestationCOSEGzip, error) {
+	var buf bytes.Buffer
+	w, err := gzip.NewWriterLevel(&buf, gzip.BestCompression)
+	if err != nil {
+		return "", fmt.Errorf("create gzip writer: %w", err)
+	}
+	if _, err := w.Write(a); err != nil {
+		return "", fmt.Errorf("gzip write: %w", err)
+	}
+	if err := w.Close(); err != nil {
+		return "", fmt.Errorf("gzip close: %w", err)
+	}
+
+	// Encode to URL-safe base64 without padding
+	encoded := base64.URLEncoding.EncodeToString(buf.Bytes())
+	encoded = strings.TrimRight(encoded, "=")
+	return AttestationCOSEGzip(encoded), nil
+}
+
+// AttestationCOSEBase64 represents standard base64-encoded COSE bytes
+type AttestationCOSEBase64 string
+
+// Decode converts base64 string to raw COSE bytes
+func (a AttestationCOSEBase64) Decode() (AttestationCOSE, error) {
+	data, err := base64.StdEncoding.DecodeString(string(a))
+	if err != nil {
+		return nil, fmt.Errorf("decode COSE base64: %w", err)
+	}
+	return AttestationCOSE(data), nil
+}
+
+// String returns the underlying string value for JSON marshaling
+func (a AttestationCOSEBase64) String() string {
+	return string(a)
+}
+
+// CompressGzip decodes, compresses with GZIP, and encodes as base64url (no padding)
+// Convenience method that combines Decode() and CompressGzip()
+func (a AttestationCOSEBase64) CompressGzip() (AttestationCOSEGzip, error) {
+	cose, err := a.Decode()
+	if err != nil {
+		return "", err
+	}
+	return cose.CompressGzip()
+}
+
+// AttestationCOSEURLBase64 represents URL-safe base64-encoded COSE bytes (no padding)
+type AttestationCOSEURLBase64 string
+
+// Decode converts URL-safe base64 string to raw COSE bytes
+func (a AttestationCOSEURLBase64) Decode() (AttestationCOSE, error) {
+	str := string(a)
+	// Add padding if needed
+	if padding := len(str) % 4; padding > 0 {
+		str += strings.Repeat("=", 4-padding)
+	}
+	data, err := base64.URLEncoding.DecodeString(str)
+	if err != nil {
+		return nil, fmt.Errorf("decode COSE URL base64: %w", err)
+	}
+	return AttestationCOSE(data), nil
+}
+
+// String returns the underlying string value
+func (a AttestationCOSEURLBase64) String() string {
+	return string(a)
+}
+
+// AttestationCOSEGzip represents GZIP-compressed, base64url-encoded (no padding) COSE bytes
+// optimized for URL inclusion. Common format for win/loss notifications and bid responses.
+// Encoding pipeline: COSE bytes → GZIP compress → base64url encode → trim padding
+type AttestationCOSEGzip string
+
+// String returns the underlying string value for JSON marshaling
+func (a AttestationCOSEGzip) String() string {
+	return string(a)
+}
+
+// Decompress decompresses and returns raw COSE bytes
+func (a AttestationCOSEGzip) Decompress() (AttestationCOSE, error) {
+	// Add padding if needed for base64url decoding
+	str := string(a)
+	if padding := len(str) % 4; padding > 0 {
+		str += strings.Repeat("=", 4-padding)
+	}
+
+	// Decode base64url
+	gzipData, err := base64.URLEncoding.DecodeString(str)
+	if err != nil {
+		return nil, fmt.Errorf("decode base64url: %w", err)
+	}
+
+	// GZIP decompress
+	reader, err := gzip.NewReader(bytes.NewReader(gzipData))
+	if err != nil {
+		return nil, fmt.Errorf("create gzip reader: %w", err)
+	}
+	defer func() { _ = reader.Close() }()
+
+	coseBytes, err := io.ReadAll(reader)
+	if err != nil {
+		return nil, fmt.Errorf("decompress: %w", err)
+	}
+
+	return AttestationCOSE(coseBytes), nil
 }

--- a/enclaveapi/types_test.go
+++ b/enclaveapi/types_test.go
@@ -1,0 +1,288 @@
+package enclaveapi
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/peterldowns/testy/check"
+)
+
+// TestAttestationCOSE_Encode tests encoding raw COSE bytes to base64
+func TestAttestationCOSE_Encode(t *testing.T) {
+	coseBytes := AttestationCOSE([]byte("mock-cose-attestation-data"))
+
+	encoded := coseBytes.EncodeBase64()
+	check.NotEqual(t, "", encoded)
+
+	decoded, err := encoded.Decode()
+	check.Nil(t, err)
+	check.Equal(t, coseBytes, decoded)
+}
+
+// TestAttestationCOSE_EncodeURLSafe tests URL-safe encoding
+func TestAttestationCOSE_EncodeURLSafe(t *testing.T) {
+	coseBytes := AttestationCOSE([]byte("mock-cose-attestation-data-for-url-encoding"))
+
+	encoded := coseBytes.EncodeURLSafe()
+	check.NotEqual(t, "", encoded)
+
+	// Should not contain padding
+	check.True(t, !strings.Contains(encoded.String(), "="))
+
+	decoded, err := encoded.Decode()
+	check.Nil(t, err)
+	check.Equal(t, coseBytes, decoded)
+}
+
+// TestAttestationCOSE_CompressGzip tests GZIP compression with URL-safe encoding
+func TestAttestationCOSE_CompressGzip(t *testing.T) {
+	coseBytes := AttestationCOSE([]byte("mock-cose-attestation-data-for-compression-testing"))
+
+	compressed, err := coseBytes.CompressGzip()
+	check.Nil(t, err)
+	check.NotEqual(t, "", compressed)
+
+	compressedStr := compressed.String()
+	check.True(t, !strings.Contains(compressedStr, "+"))
+	check.True(t, !strings.Contains(compressedStr, "/"))
+	check.True(t, !strings.Contains(compressedStr, "="))
+
+	for _, char := range compressedStr {
+		valid := (char >= 'A' && char <= 'Z') ||
+			(char >= 'a' && char <= 'z') ||
+			(char >= '0' && char <= '9') ||
+			char == '-' || char == '_'
+		check.True(t, valid)
+	}
+
+	decompressed, err := compressed.Decompress()
+	check.Nil(t, err)
+	check.Equal(t, coseBytes, decompressed)
+}
+
+// TestAttestationCOSE_CompressGzip_Deterministic tests that compression is deterministic
+func TestAttestationCOSE_CompressGzip_Deterministic(t *testing.T) {
+	coseBytes := AttestationCOSE([]byte("mock-cose-attestation-data"))
+
+	result1, err1 := coseBytes.CompressGzip()
+	check.Nil(t, err1)
+
+	result2, err2 := coseBytes.CompressGzip()
+	check.Nil(t, err2)
+
+	check.Equal(t, result1, result2)
+}
+
+// TestAttestationCOSEBase64_Decode tests decoding base64 to raw bytes
+func TestAttestationCOSEBase64_Decode(t *testing.T) {
+	tests := []struct {
+		name      string
+		input     AttestationCOSEBase64
+		wantErr   bool
+		errSubstr string
+	}{
+		{
+			name:    "valid base64",
+			input:   "bW9jay1jb3NlLWF0dGVzdGF0aW9u",
+			wantErr: false,
+		},
+		{
+			name:      "invalid base64 - illegal characters",
+			input:     "not-valid-base64!!!@@@",
+			wantErr:   true,
+			errSubstr: "decode COSE base64",
+		},
+		{
+			name:      "invalid base64 - wrong padding",
+			input:     "abc",
+			wantErr:   true,
+			errSubstr: "decode COSE base64",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := tt.input.Decode()
+
+			if tt.wantErr {
+				check.NotNil(t, err)
+				check.True(t, strings.Contains(err.Error(), tt.errSubstr))
+				check.Nil(t, result)
+			} else {
+				check.Nil(t, err)
+				check.NotNil(t, result)
+			}
+		})
+	}
+}
+
+// TestAttestationCOSEBase64_CompressGzip tests convenience method
+func TestAttestationCOSEBase64_CompressGzip(t *testing.T) {
+	coseBase64 := AttestationCOSEBase64("bW9jay1jb3NlLWF0dGVzdGF0aW9uLWRhdGEtZm9yLXRlc3RpbmctcHVycG9zZXMtb25seQ==")
+
+	compressed, err := coseBase64.CompressGzip()
+
+	check.Nil(t, err)
+	check.NotEqual(t, "", compressed)
+
+	// Verify URL-safe encoding
+	compressedStr := compressed.String()
+	check.True(t, !strings.Contains(compressedStr, "+"))
+	check.True(t, !strings.Contains(compressedStr, "/"))
+	check.True(t, !strings.Contains(compressedStr, "="))
+}
+
+// TestAttestationCOSEBase64_CompressGzip_Empty tests empty input
+func TestAttestationCOSEBase64_CompressGzip_Empty(t *testing.T) {
+	empty := AttestationCOSEBase64("")
+
+	compressed, err := empty.CompressGzip()
+
+	check.Nil(t, err)
+	check.NotEqual(t, "", compressed)
+}
+
+// TestAttestationCOSEURLBase64_Decode tests URL-safe decoding with padding restoration
+func TestAttestationCOSEURLBase64_Decode(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    AttestationCOSEURLBase64
+		expected AttestationCOSE
+	}{
+		{
+			name:     "no padding needed (len % 4 == 0)",
+			input:    "YWJj",
+			expected: AttestationCOSE([]byte("abc")),
+		},
+		{
+			name:     "needs 2 chars padding (len % 4 == 2)",
+			input:    "dGVzdA",
+			expected: AttestationCOSE([]byte("test")),
+		},
+		{
+			name:     "needs 1 char padding (len % 4 == 3)",
+			input:    "dGVzdGluZw",
+			expected: AttestationCOSE([]byte("testing")),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := tt.input.Decode()
+			check.Nil(t, err)
+			check.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+// TestAttestationCOSEGzip_Decompress tests decompression
+func TestAttestationCOSEGzip_Decompress(t *testing.T) {
+	original := AttestationCOSE([]byte("mock-cose-attestation-data-for-compression-testing"))
+	compressed, err := original.CompressGzip()
+	check.Nil(t, err)
+
+	decompressed, err := compressed.Decompress()
+
+	check.Nil(t, err)
+	check.Equal(t, original, decompressed)
+}
+
+// TestAttestationCOSEGzip_Decompress_Invalid tests error handling
+func TestAttestationCOSEGzip_Decompress_Invalid(t *testing.T) {
+	tests := []struct {
+		name           string
+		input          AttestationCOSEGzip
+		errorSubstring string
+	}{
+		{
+			name:           "invalid base64url",
+			input:          "!!!invalid!!!",
+			errorSubstring: "decode base64url",
+		},
+		{
+			name:           "valid base64 but not gzip",
+			input:          "bW9jaw",
+			errorSubstring: "gzip",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := tt.input.Decompress()
+
+			check.NotNil(t, err)
+			check.Nil(t, result)
+
+			check.True(t, strings.Contains(err.Error(), tt.errorSubstring))
+		})
+	}
+}
+
+// TestAttestationTypes_JSONMarshaling tests that types marshal/unmarshal correctly as JSON
+func TestAttestationTypes_JSONMarshaling(t *testing.T) {
+	type TestStruct struct {
+		Attestation AttestationCOSEBase64 `json:"attestation"`
+	}
+
+	coseData := AttestationCOSE([]byte("mock-cose"))
+	original := TestStruct{
+		Attestation: coseData.EncodeBase64(),
+	}
+
+	jsonData, err := original.Attestation.Decode()
+	check.Nil(t, err)
+
+	encoded := jsonData.EncodeBase64()
+	check.Equal(t, original.Attestation, encoded)
+}
+
+// TestAttestationTypes_RoundTrip tests complete round-trip conversions
+func TestAttestationTypes_RoundTrip(t *testing.T) {
+	t.Run("Standard base64 round-trip", func(t *testing.T) {
+		original := AttestationCOSE([]byte("test-cose-data"))
+
+		// COSE → Base64 → COSE
+		encoded := original.EncodeBase64()
+		decoded, err := encoded.Decode()
+
+		check.Nil(t, err)
+		check.Equal(t, original, decoded)
+	})
+
+	t.Run("URL-safe base64 round-trip", func(t *testing.T) {
+		original := AttestationCOSE([]byte("test-cose-data-for-url"))
+
+		// COSE → URLBase64 → COSE
+		encoded := original.EncodeURLSafe()
+		decoded, err := encoded.Decode()
+
+		check.Nil(t, err)
+		check.Equal(t, original, decoded)
+	})
+
+	t.Run("Gzip compression round-trip", func(t *testing.T) {
+		original := AttestationCOSE([]byte("test-cose-data-for-compression-with-enough-data-to-actually-compress-meaningfully"))
+
+		// COSE → Gzip → COSE
+		compressed, err := original.CompressGzip()
+		check.Nil(t, err)
+
+		decompressed, err := compressed.Decompress()
+		check.Nil(t, err)
+		check.Equal(t, original, decompressed)
+	})
+
+	t.Run("Base64 → Gzip compression", func(t *testing.T) {
+		original := AttestationCOSEBase64("bW9jay1jb3NlLWF0dGVzdGF0aW9uLWRhdGEtZm9yLXRlc3RpbmctcHVycG9zZXMtb25seQ==")
+
+		// Base64 → Gzip → COSE → Base64
+		compressed, err := original.CompressGzip()
+		check.Nil(t, err)
+
+		decompressed, err := compressed.Decompress()
+		check.Nil(t, err)
+
+		reencoded := decompressed.EncodeBase64()
+		check.Equal(t, original, reencoded)
+	})
+}

--- a/validation/attestation.go
+++ b/validation/attestation.go
@@ -13,9 +13,9 @@ import (
 // validateCommonAttestation performs validation common to all attestation types
 // Parses the COSE bytes internally and validates PCRs, certificate chain, and signature
 // Returns BaseValidationResult with validation results
-func validateCommonAttestation(attestationCOSEBase64 string) (*BaseValidationResult, error) {
+func validateCommonAttestation(attestationCOSEBase64 enclaveapi.AttestationCOSEBase64) (*BaseValidationResult, error) {
 	// Decode and parse COSE to get attestation document
-	coseBytes, err := base64.StdEncoding.DecodeString(attestationCOSEBase64)
+	coseBytes, err := attestationCOSEBase64.Decode()
 	if err != nil {
 		return nil, fmt.Errorf("decode COSE bytes: %w", err)
 	}

--- a/validation/cmd/key-validator/main.go
+++ b/validation/cmd/key-validator/main.go
@@ -110,7 +110,7 @@ func readKeyResponse(path string) (*enclaveapi.KeyResponse, error) {
 		return nil, fmt.Errorf("failed to parse JSON: %w", err)
 	}
 
-	if keyResponse.AttestationCOSEBase64 == "" {
+	if keyResponse.AttestationCOSEBase64.String() == "" {
 		return nil, fmt.Errorf("missing attestation_cose_base64 field in key response")
 	}
 

--- a/validation/cmd/key-validator/main.go
+++ b/validation/cmd/key-validator/main.go
@@ -13,39 +13,43 @@ import (
 func main() {
 	// Define CLI flags
 	var (
-		attestationPath = flag.String("attestation", "", "Path to key response JSON file (required)")
-		publicKeyPath   = flag.String("public-key", "", "Path to public key PEM file (required)")
-		outputFormat    = flag.String("format", "text", "Output format: text or json")
-		help            = flag.Bool("help", false, "Show usage information")
+		outputFormat = flag.String("format", "text", "Output format: text or json")
+		help         = flag.Bool("help", false, "Show usage information")
 	)
 
 	flag.Parse()
 
 	// Show help
-	if *help || *attestationPath == "" || *publicKeyPath == "" {
+	if *help {
 		showUsage()
-		if *attestationPath == "" || *publicKeyPath == "" {
-			os.Exit(1)
-		}
 		os.Exit(0)
 	}
 
-	// Read key response file
-	keyResponse, err := readKeyResponse(*attestationPath)
+	// Check for JSON input argument
+	if flag.NArg() == 0 {
+		showUsage()
+		fmt.Fprintf(os.Stderr, "\nError: JSON input is required\n")
+		os.Exit(1)
+	}
+
+	// Parse JSON input
+	jsonInput := flag.Arg(0)
+	keyWithAttestation, err := parseKeyWithAttestation(jsonInput)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error reading attestation: %v\n", err)
+		fmt.Fprintf(os.Stderr, "Error parsing JSON input: %v\n", err)
 		os.Exit(2)
 	}
 
-	// Read public key file
-	publicKey, err := readPublicKey(*publicKeyPath)
+	// Convert AttestationCOSEGzip to AttestationCOSEBase64
+	attestationCOSE, err := keyWithAttestation.Attestation.Decompress()
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error reading public key: %v\n", err)
+		fmt.Fprintf(os.Stderr, "Error decompressing attestation: %v\n", err)
 		os.Exit(2)
 	}
+	attestationCOSEBase64 := attestationCOSE.EncodeBase64()
 
 	// Validate using library
-	result, err := validation.ValidateKeyAttestation(keyResponse.AttestationCOSEBase64, publicKey)
+	result, err := validation.ValidateKeyAttestation(attestationCOSEBase64, keyWithAttestation.PublicKey)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Validation error: %v\n", err)
 		os.Exit(2)
@@ -72,22 +76,27 @@ func showUsage() {
 	fmt.Println("Example CLI tool demonstrating the validation library.")
 	fmt.Println()
 	fmt.Println("Usage:")
-	fmt.Println("  tee-key-validator --attestation <path> --public-key <pem> [options]")
+	fmt.Println("  tee-key-validator <json-input> [options]")
 	fmt.Println()
-	fmt.Println("Required Flags:")
-	fmt.Println("  --attestation <path>              Path to key response JSON file")
-	fmt.Println("  --public-key <path>               Path to public key PEM file")
+	fmt.Println("Arguments:")
+	fmt.Println("  <json-input>                      JSON string containing public_key and attestation_cose_gzip_base64")
 	fmt.Println()
 	fmt.Println("Optional Flags:")
 	fmt.Println("  --format <text|json>              Output format (default: text)")
 	fmt.Println("  --help                            Show this help message")
 	fmt.Println()
+	fmt.Println("JSON Input Format:")
+	fmt.Println("  {")
+	fmt.Println("    \"public_key\": \"-----BEGIN PUBLIC KEY-----\\n...\",")
+	fmt.Println("    \"attestation_cose_gzip_base64\": \"H4sIAAAA...\"")
+	fmt.Println("  }")
+	fmt.Println()
 	fmt.Println("Examples:")
 	fmt.Println("  # Validate key attestation")
-	fmt.Println("  tee-key-validator --attestation response.json --public-key public_key.pem")
+	fmt.Println("  tee-key-validator '{\"public_key\":\"...\",\"attestation_cose_gzip_base64\":\"...\"}'")
 	fmt.Println()
 	fmt.Println("  # JSON output")
-	fmt.Println("  tee-key-validator --attestation response.json --public-key public_key.pem --format json")
+	fmt.Println("  tee-key-validator --format json '{\"public_key\":\"...\",\"attestation_cose_gzip_base64\":\"...\"}'")
 	fmt.Println()
 	fmt.Println("Exit Codes:")
 	fmt.Println("  0 - Validation passed")
@@ -99,31 +108,21 @@ func showUsage() {
 	fmt.Println("  github.com/cloudx-io/openauction/validation")
 }
 
-func readKeyResponse(path string) (*enclaveapi.KeyResponse, error) {
-	data, err := os.ReadFile(path)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read file: %w", err)
-	}
-
-	var keyResponse enclaveapi.KeyResponse
-	if err := json.Unmarshal(data, &keyResponse); err != nil {
+func parseKeyWithAttestation(jsonInput string) (*enclaveapi.KeyWithAttestation, error) {
+	var keyWithAttestation enclaveapi.KeyWithAttestation
+	if err := json.Unmarshal([]byte(jsonInput), &keyWithAttestation); err != nil {
 		return nil, fmt.Errorf("failed to parse JSON: %w", err)
 	}
 
-	if keyResponse.AttestationCOSEBase64.String() == "" {
-		return nil, fmt.Errorf("missing attestation_cose_base64 field in key response")
+	if keyWithAttestation.PublicKey == "" {
+		return nil, fmt.Errorf("missing public_key field in JSON input")
 	}
 
-	return &keyResponse, nil
-}
-
-func readPublicKey(path string) (string, error) {
-	data, err := os.ReadFile(path)
-	if err != nil {
-		return "", fmt.Errorf("failed to read file: %w", err)
+	if keyWithAttestation.Attestation.String() == "" {
+		return nil, fmt.Errorf("missing attestation_cose_gzip_base64 field in JSON input")
 	}
 
-	return string(data), nil
+	return &keyWithAttestation, nil
 }
 
 func outputText(result *validation.KeyValidationResult) {

--- a/validation/cose.go
+++ b/validation/cose.go
@@ -8,6 +8,8 @@ import (
 
 	"github.com/fxamacker/cbor/v2"
 	"github.com/veraison/go-cose"
+
+	enclaveapi "github.com/cloudx-io/openauction/enclaveapi"
 )
 
 // ExtractCOSEPayload extracts the payload from a COSE_Sign1 4-element array
@@ -33,9 +35,9 @@ func ExtractCOSEPayload(coseBytes []byte) ([]byte, error) {
 }
 
 // VerifyCOSESignature verifies a COSE_Sign1 signature given base64-encoded COSE bytes and certificate
-func VerifyCOSESignature(coseB64 string, certB64 string) error {
+func VerifyCOSESignature(coseB64 enclaveapi.AttestationCOSEBase64, certB64 string) error {
 	// Decode base64 COSE bytes
-	coseBytes, err := base64.StdEncoding.DecodeString(coseB64)
+	coseBytes, err := coseB64.Decode()
 	if err != nil {
 		return fmt.Errorf("decode COSE bytes: %w", err)
 	}

--- a/validation/keyvalidation.go
+++ b/validation/keyvalidation.go
@@ -22,7 +22,7 @@ import (
 // Returns:
 //   - KeyValidationResult with detailed results (call result.IsValid() to check overall status)
 //   - error if validation cannot be performed (e.g., malformed input, missing config)
-func ValidateKeyAttestation(attestationCOSEBase64 string, expectedPublicKey string) (*KeyValidationResult, error) {
+func ValidateKeyAttestation(attestationCOSEBase64 enclaveapi.AttestationCOSEBase64, expectedPublicKey string) (*KeyValidationResult, error) {
 	// Perform common attestation validation (PCRs, certificate, signature)
 	baseResult, err := validateCommonAttestation(attestationCOSEBase64)
 	if err != nil {
@@ -64,9 +64,9 @@ func ValidateKeyAttestation(attestationCOSEBase64 string, expectedPublicKey stri
 
 // parseKeyAttestationFromCOSE parses a KeyAttestationDoc from base64-encoded COSE bytes
 // This extracts the attestation document from the COSE_Sign1 payload
-func parseKeyAttestationFromCOSE(attestationCOSEB64 string) (*enclaveapi.KeyAttestationDoc, error) {
+func parseKeyAttestationFromCOSE(attestationCOSEB64 enclaveapi.AttestationCOSEBase64) (*enclaveapi.KeyAttestationDoc, error) {
 	// Decode base64 COSE bytes
-	coseBytes, err := base64.StdEncoding.DecodeString(attestationCOSEB64)
+	coseBytes, err := attestationCOSEB64.Decode()
 	if err != nil {
 		return nil, fmt.Errorf("decode COSE bytes: %w", err)
 	}


### PR DESCRIPTION
## Summary

Add type definitions for COSE attestation data with encoding/decoding methods to improve type safety and provide a complete reference implementation for third parties.

- Add `AttestationCOSE`, `AttestationCOSEBase64`, `AttestationCOSEURLBase64`, and `AttestationCOSEGzip` types
- Implement encoding/decoding/compression methods on attestation types
- Maintain compatibility with JSON marshaling

## Changes

### New Types

1. **`AttestationCOSE`** - Raw COSE_Sign1 bytes from AWS Nitro Enclaves
   - `EncodeBase64()` → `AttestationCOSEBase64`
   - `EncodeURLSafe()` → `AttestationCOSEURLBase64`
   - `CompressGzip()` → `AttestationCOSEGzip`

2. **`AttestationCOSEBase64`** - Standard base64-encoded COSE bytes
   - `Decode()` → `AttestationCOSE`
   - `CompressGzip()` → `AttestationCOSEGzip`
   - `String()` for JSON marshaling

3. **`AttestationCOSEURLBase64`** - URL-safe base64 (no padding)
   - `Decode()` with automatic padding restoration
   - `String()` for JSON marshaling

4. **`AttestationCOSEGzip`** - GZIP-compressed + base64url-encoded (no padding)
   - `Decompress()` → `AttestationCOSE`
   - `String()` for JSON marshaling

### API Changes

**Struct Fields:**
- `EnclaveAuctionResponse.AttestationCOSEBase64`: `string` → `AttestationCOSEBase64`
- `KeyResponse.AttestationCOSEBase64`: `string` → `AttestationCOSEBase64`

**Function Signatures:**
- `GenerateTEEProofs()`: Returns `AttestationCOSE` instead of `[]byte`
- `GenerateAttestation()`: Returns `AttestationCOSE` instead of `[]byte`
- `GenerateKeyAttestation()`: Returns `AttestationCOSE` instead of `[]byte`
- `ValidateKeyAttestation()`: Accepts `AttestationCOSEBase64` parameter instead of `string`
- `VerifyCOSESignature()`: Accepts `AttestationCOSEBase64` parameter instead of `string`

### Implementation Updates

**Enclave (`enclave/`):**
- Use `.Encode()` method instead of manual base64 encoding
- Updated variable names for clarity (`coseAttestation` instead of `attestationCBOR`)
- Removed unnecessary `encoding/base64` imports

**Validation (`validation/`):**
- Use `.Decode()` method instead of manual base64 decoding
- Type-safe function signatures throughout
- Key validator CLI updated to use `.String()` for empty checks

## Benefits

1. **Type Safety:** Cannot accidentally mix up different encoding formats (base64 vs base64url vs gzipped)
2. **Self-Documenting:** Types make encoding format explicit without verbose names
3. **Third-Party Ready:** Complete reference implementation for handling COSE attestations
4. **Convenience:** Methods like `.EncodeBase64()`, `.Decode()`, `.CompressGzip()` make conversions explicit and readable
5. **Backward Compatible:** JSON marshaling/unmarshaling works transparently since types wrap primitives
6. **Testable:** Compression/decompression logic can be tested directly on types

## Test Plan

All existing tests pass. Adds test coverage for the new functions.

## Breaking Changes

None. While internal signatures changed, JSON format remains identical and the types automatically marshal/unmarshal as their underlying primitives.