### PR TITLE
remove enclaveapi.EnclaveAuctionRequest.AttestationDoc and cleanup parsing code

### DIFF
--- a/enclave/auction.go
+++ b/enclave/auction.go
@@ -26,7 +26,6 @@ func ProcessAuction(attester EnclaveAttester, req enclaveapi.EnclaveAuctionReque
 			Type:           "auction_response",
 			Success:        false,
 			Message:        fmt.Sprintf("Invalid negative floor price %.4f", req.BidFloor),
-			AttestationDoc: nil,
 			ProcessingTime: time.Since(startTime).Milliseconds(),
 		}
 	}
@@ -57,7 +56,7 @@ func ProcessAuction(attester EnclaveAttester, req enclaveapi.EnclaveAuctionReque
 	winner := auctionResult.Winner
 	runnerUp := auctionResult.RunnerUp
 
-	teeData, coseAttestation, err := GenerateTEEProofs(attester, req, unencryptedBids, winner, runnerUp)
+	coseAttestation, err := GenerateTEEProofs(attester, req, unencryptedBids, winner, runnerUp)
 	processingTime := time.Since(startTime).Milliseconds()
 
 	log.Printf("INFO: Auction complete: winner=%s (%.2f), runner-up=%s (%.2f), processing=%dms",
@@ -71,7 +70,6 @@ func ProcessAuction(attester EnclaveAttester, req enclaveapi.EnclaveAuctionReque
 			Type:           "auction_response",
 			Success:        false,
 			Message:        fmt.Sprintf("Enclave processing failed: %v", err),
-			AttestationDoc: nil,
 			ProcessingTime: processingTime,
 		}
 	}
@@ -80,7 +78,6 @@ func ProcessAuction(attester EnclaveAttester, req enclaveapi.EnclaveAuctionReque
 		Type:                  "auction_response",
 		Success:               true,
 		Message:               fmt.Sprintf("Processed %d bids in enclave", len(req.Bids)),
-		AttestationDoc:        teeData,
 		AttestationCOSEBase64: coseAttestation.EncodeBase64(),
 		ExcludedBids:          excludedBids,
 		FloorRejectedBidIDs:   floorRejectedBidIDs,

--- a/enclave/proofs_test.go
+++ b/enclave/proofs_test.go
@@ -137,12 +137,11 @@ func TestGenerateAttestation(t *testing.T) {
 
 	// Test with nil enclave handle (error case)
 	bidHashes := []string{"hash1", "hash2"}
-	attestationDoc, coseBytes, err := GenerateAttestation(nil, req, bidHashes, "test_request_hash", "test_adj_hash",
+	coseBytes, err := GenerateAttestation(nil, req, bidHashes, "test_request_hash", "test_adj_hash",
 		"test_bid_nonce", "test_req_nonce", "test_adj_nonce", winner, runnerUp)
 
 	// Should fail with nil enclave handle
 	check.Error(t, err)
-	check.Nil(t, attestationDoc)
 	check.Nil(t, coseBytes)
 	check.True(t, strings.Contains(err.Error(), "enclave attester is nil"))
 }
@@ -168,14 +167,15 @@ func TestGenerateAttestationWithMock(t *testing.T) {
 	bidHash := generateBidHash("bid1", 2.50, bidHashNonce)
 
 	// Test successful attestation generation with mock
-	attestationDoc, coseBytes, err := GenerateAttestation(mockEnclave, req, []string{bidHash}, "test_request_hash", "test_adj_hash",
+	coseBytes, err := GenerateAttestation(mockEnclave, req, []string{bidHash}, "test_request_hash", "test_adj_hash",
 		bidHashNonce, "test_req_nonce", "test_adj_nonce", winner, nil)
 
 	// Should succeed with mock enclave
 	check.NoError(t, err)
-	check.NotNil(t, attestationDoc)
 	check.NotNil(t, coseBytes)
 	check.True(t, len(coseBytes) > 0)
+
+	attestationDoc := parseAuctionAttestationFromCOSE(t, coseBytes)
 	check.Equal(t, "test-enclave-12345", attestationDoc.ModuleID)
 	check.Equal(t, "SHA384", attestationDoc.DigestAlgorithm)
 	check.NotNil(t, attestationDoc.UserData)
@@ -243,14 +243,15 @@ func TestGenerateAttestationWithEncryptedBids(t *testing.T) {
 	bidHashes := []string{hash2, hash3}
 
 	// Test successful attestation generation with encrypted bids
-	attestationDoc, coseBytes, err := GenerateAttestation(mockEnclave, req, bidHashes, "test_request_hash", "test_adj_hash",
+	coseBytes, err := GenerateAttestation(mockEnclave, req, bidHashes, "test_request_hash", "test_adj_hash",
 		bidHashNonce, "test_req_nonce", "test_adj_nonce", winner, runnerUp)
 
 	// Should succeed with mock enclave
 	check.NoError(t, err)
-	check.NotNil(t, attestationDoc)
 	check.NotNil(t, coseBytes)
 	check.True(t, len(coseBytes) > 0)
+
+	attestationDoc := parseAuctionAttestationFromCOSE(t, coseBytes)
 	check.Equal(t, "test-enclave-12345", attestationDoc.ModuleID)
 	check.Equal(t, "SHA384", attestationDoc.DigestAlgorithm)
 
@@ -513,14 +514,15 @@ func TestGenerateAttestationWithMixedBidTypes(t *testing.T) {
 	bidHashes := []string{hashU1, hashE1, hashU2, hashE2, hashU3}
 
 	// Generate attestation for mixed bid scenario
-	attestationDoc, coseBytes, err := GenerateAttestation(mockEnclave, req, bidHashes, "mixed_request_hash", "mixed_adj_hash",
+	coseBytes, err := GenerateAttestation(mockEnclave, req, bidHashes, "mixed_request_hash", "mixed_adj_hash",
 		bidHashNonce, "mixed_req_nonce", "mixed_adj_nonce", winner, runnerUp)
 
 	// Verify successful attestation generation
 	check.NoError(t, err)
-	check.NotNil(t, attestationDoc)
 	check.NotNil(t, coseBytes)
 	check.True(t, len(coseBytes) > 0)
+
+	attestationDoc := parseAuctionAttestationFromCOSE(t, coseBytes)
 	check.Equal(t, "test-enclave-12345", attestationDoc.ModuleID)
 
 	// Verify user data reflects the mixed bid scenario

--- a/enclave/testutils.go
+++ b/enclave/testutils.go
@@ -2,11 +2,14 @@ package main
 
 import (
 	"encoding/hex"
+	"encoding/json"
 	"fmt"
 	"testing"
 
 	enclave "github.com/edgebitio/nitro-enclaves-sdk-go"
 	"github.com/fxamacker/cbor/v2"
+
+	"github.com/cloudx-io/openauction/enclaveapi"
 )
 
 // MockEnclaveHandle implements the Attest method for testing
@@ -68,5 +71,28 @@ func CreateMockEnclave(t *testing.T) *MockEnclaveHandle {
 
 			return cbor.Marshal(result) // Proper CBOR encoding
 		},
+	}
+}
+
+// parseAuctionAttestationFromCOSE is a shared test helper that parses COSE attestation bytes
+// and returns an AuctionAttestationDoc with parsed user data
+func parseAuctionAttestationFromCOSE(t *testing.T, coseBytes enclaveapi.AttestationCOSE) *enclaveapi.AuctionAttestationDoc {
+	t.Helper()
+
+	// Parse attestation document and user data
+	attestationDoc, userDataBytes, err := coseBytes.ParseAttestationDoc()
+	if err != nil {
+		t.Fatalf("Failed to parse attestation: %v", err)
+	}
+
+	// Parse the UserData JSON into AttestationUserData
+	var userData enclaveapi.AuctionAttestationUserData
+	if err := json.Unmarshal(userDataBytes, &userData); err != nil {
+		t.Fatalf("Failed to unmarshal user data: %v", err)
+	}
+
+	return &enclaveapi.AuctionAttestationDoc{
+		AttestationDoc: attestationDoc,
+		UserData:       &userData,
 	}
 }

--- a/enclaveapi/parsing/nitro.go
+++ b/enclaveapi/parsing/nitro.go
@@ -7,19 +7,6 @@ import (
 	enclaveapi "github.com/cloudx-io/openauction/enclaveapi"
 )
 
-// NitroAttestationDocument represents the raw CBOR structure from AWS Nitro Enclaves
-type NitroAttestationDocument struct {
-	ModuleID    string            `cbor:"module_id"`
-	Digest      string            `cbor:"digest"`
-	Timestamp   uint64            `cbor:"timestamp"`
-	PCRs        map[uint64][]byte `cbor:"pcrs"`
-	Certificate []byte            `cbor:"certificate"`
-	CABundle    [][]byte          `cbor:"cabundle"`
-	PublicKey   []byte            `cbor:"public_key"`
-	UserData    []byte            `cbor:"user_data"`
-	Nonce       []byte            `cbor:"nonce"`
-}
-
 // FormatPCR formats PCR bytes as hex string
 func FormatPCR(pcrData []byte) string {
 	if len(pcrData) == 0 {


### PR DESCRIPTION
## Summary
- Removes the deprecated `AttestationDoc` field from `EnclaveAuctionResponse` 
- Introduces a clean, reusable `AttestationCOSE.ParseAttestationDoc()` method for parsing attestations
- Eliminates duplicate parsing logic across enclave, validation, and test code

### Breaking Changes
The `attestation_document` JSON field has been removed from `EnclaveAuctionResponse`. Clients must now use `attestation_cose_base64` instead.

**Before:**
```go
response.AttestationDoc.UserData.Winner
```

**After:**
```go
attestationDoc, userDataBytes, err := response.AttestationCOSEBase64.Decode().ParseAttestationDoc()
// Then unmarshal userDataBytes into AttestationUserData
```

### Implementation Details

**New API:**
- Added `AttestationCOSE.ParseAttestationDoc()` method that extracts `AttestationDoc` and raw user data from COSE bytes
- All parsing now goes through consistent code path

**Code cleanup:**
- Deleted deprecated `ParseCBORAttestation()` function
- Deleted `extractAttestationDoc()` helper
- Refactored `ParseKeyAttestation()` to use new method
- Simplified validation code by removing redundant `ExtractCOSEPayload()` step

**Test improvements:**

- Updated 80+ test assertions to use new parsing method

### Test Plan
- [x] All `openauction` tests passing (core, enclave, enclaveapi, validation)
- [x] Verified backward compatibility for clients using `attestation_cose_base64`