### PR TITLE
build EIF using Github actions

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,4 +1,4 @@
-name: build docker container image via Github Actions
+name: Docker Build
 on:
   workflow_run:
     workflows: ["Go"]

--- a/.github/workflows/eif-build.yml
+++ b/.github/workflows/eif-build.yml
@@ -1,0 +1,340 @@
+name: Build EIF
+run-name: Build EIF - ${{ github.event.workflow_run.head_sha }}
+
+# This workflow builds Enclave Image Files (EIFs) for AWS Nitro Enclaves
+# EIFs can only be built on Nitro-compatible EC2 instances, so this workflow:
+# 1. Launches an ephemeral Nitro EC2 instance
+# 2. Builds the EIF from the Docker image
+# 3. Pushes the EIF to ECR as an OCI artifact
+# 4. Terminates the instance
+#
+# IAM Requirements:
+#
+# 1. GitHub Actions OIDC Role (eif-builder-workflow)
+#    This role is assumed by the GitHub Actions runner and needs:
+#    - ecr:GetAuthorizationToken (for ECR login)
+#    - ecr:PutImage, ecr:InitiateLayerUpload, etc. (to push EIF artifacts)
+#    - ec2:RunInstances, ec2:TerminateInstances (to manage build instance)
+#    - ec2:CreateKeyPair, ec2:DeleteKeyPair (for SSH access)
+#    - ec2:CreateSecurityGroup, ec2:DeleteSecurityGroup (for SSH access)
+#    - ec2:Describe* (to query VPC, subnets, instances)
+#    - iam:PassRole (to attach instance profile to EC2 instance)
+#
+# 2. EC2 Instance Profile (eif-builder-instance)
+#    This profile is attached to the ephemeral EC2 instance and needs:
+#    - ecr:GetAuthorizationToken (for ECR login from instance)
+#    - ecr:BatchGetImage, ecr:GetDownloadUrlForLayer (to pull Docker image)
+#    - ec2:DescribeInstances (for instance metadata access)
+
+on:
+  workflow_run:
+    workflows: ["Docker Build"]
+    types: [completed]
+    branches: [main]
+  workflow_dispatch:
+
+env:
+  AWS_REGION: us-east-1
+  INSTANCE_TYPE: c5.xlarge
+  # Amazon Linux 2023 AMI
+  # Update periodically to latest AMI
+  #
+  # % aws ec2 describe-images \
+  #  --owners amazon \
+  #  --filters "Name=name,Values=al2023-ami-2023.*-x86_64" \
+  #  --filters "Name=state,Values=available" \
+  #  --query 'sort_by(Images, &CreationDate)[-1].[ImageId,Name,CreationDate]' \
+  #  --output table \
+  #  --region us-east-1
+  AMI_ID: ami-08d7aabbb50c2c24e 
+
+jobs:
+  build-eif:
+    name: Build EIF on Nitro EC2
+    runs-on: ubuntu-latest
+    if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
+    permissions:
+      id-token: write
+      contents: read
+    
+    outputs:
+      pcr0: ${{ steps.extract-pcrs.outputs.pcr0 }}
+      pcr1: ${{ steps.extract-pcrs.outputs.pcr1 }}
+      pcr2: ${{ steps.extract-pcrs.outputs.pcr2 }}
+      eif_sha256: ${{ steps.extract-pcrs.outputs.eif_sha256 }}
+    
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
+      
+      - name: Set commit SHA variable
+        id: set-sha
+        run: |
+          if [ -n "${{ github.event.workflow_run.head_sha }}" ]; then
+            COMMIT_SHA="${{ github.event.workflow_run.head_sha }}"
+          else
+            COMMIT_SHA="${{ github.sha }}"
+          fi
+          echo "commit_sha=${COMMIT_SHA}" >> $GITHUB_OUTPUT
+          echo "commit_short=${COMMIT_SHA:0:7}" >> $GITHUB_OUTPUT
+          echo "Building EIF for commit: ${COMMIT_SHA}"
+      
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          # OIDC role for EIF building workflow (needs EC2 + ECR permissions)
+          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/eif-builder-workflow
+          aws-region: ${{ env.AWS_REGION }}
+      
+      - name: Construct Docker image URI
+        id: image-uri
+        run: |
+          COMMIT_SHA="${{ steps.set-sha.outputs.commit_sha }}"
+          IMAGE_URI="${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${{ env.AWS_REGION }}.amazonaws.com/cloudx-io/openauction/enclave:sha-${COMMIT_SHA}"
+          echo "image_uri=${IMAGE_URI}" >> $GITHUB_OUTPUT
+          echo "Docker image: ${IMAGE_URI}"
+      
+      - name: Create EC2 key pair
+        id: create-key
+        run: |
+          KEY_NAME="eif-builder-${{ github.run_id }}-${{ github.run_attempt }}"
+          aws ec2 create-key-pair \
+            --key-name "${KEY_NAME}" \
+            --query 'KeyMaterial' \
+            --output text > /tmp/eif-builder-key.pem
+          chmod 400 /tmp/eif-builder-key.pem
+          echo "key_name=${KEY_NAME}" >> $GITHUB_OUTPUT
+          echo "Created key pair: ${KEY_NAME}"
+      
+      - name: Get default VPC and subnet
+        id: vpc-info
+        run: |
+          VPC_ID=$(aws ec2 describe-vpcs \
+            --filters "Name=isDefault,Values=true" \
+            --query 'Vpcs[0].VpcId' \
+            --output text)
+          
+          SUBNET_ID=$(aws ec2 describe-subnets \
+            --filters "Name=vpc-id,Values=${VPC_ID}" \
+            --query 'Subnets[0].SubnetId' \
+            --output text)
+          
+          echo "vpc_id=${VPC_ID}" >> $GITHUB_OUTPUT
+          echo "subnet_id=${SUBNET_ID}" >> $GITHUB_OUTPUT
+          echo "Using VPC: ${VPC_ID}, Subnet: ${SUBNET_ID}"
+      
+      - name: Create security group
+        id: security-group
+        run: |
+          SG_NAME="eif-builder-${{ github.run_id }}"
+          SG_ID=$(aws ec2 create-security-group \
+            --group-name "${SG_NAME}" \
+            --description "Temporary SG for EIF building - Run ${{ github.run_id }}" \
+            --vpc-id "${{ steps.vpc-info.outputs.vpc_id }}" \
+            --query 'GroupId' \
+            --output text)
+          
+          aws ec2 authorize-security-group-ingress \
+            --group-id "${SG_ID}" \
+            --protocol tcp \
+            --port 22 \
+            --cidr 0.0.0.0/0
+          
+          echo "security_group_id=${SG_ID}" >> $GITHUB_OUTPUT
+          echo "Created security group: ${SG_ID}"
+      
+      - name: Launch Nitro EC2 instance
+        id: launch-instance
+        run: |
+          # Launch Nitro-enabled instance with IAM instance profile
+          # The instance profile (eif-builder-instance) allows the instance to:
+          # - Pull Docker images from ECR
+          # - Access EC2 instance metadata
+
+          INSTANCE_ID=$(aws ec2 run-instances \
+            --image-id ${{ env.AMI_ID }} \
+            --instance-type ${{ env.INSTANCE_TYPE }} \
+            --key-name "${{ steps.create-key.outputs.key_name }}" \
+            --security-group-ids "${{ steps.security-group.outputs.security_group_id }}" \
+            --subnet-id "${{ steps.vpc-info.outputs.subnet_id }}" \
+            --enclave-options 'Enabled=true' \
+            --tag-specifications 'ResourceType=instance,Tags=[{Key=Name,Value=eif-builder},{Key=Purpose,Value=EIF-Build}]' \
+            --iam-instance-profile Name=eif-builder-instance \
+            --query 'Instances[0].InstanceId' \
+            --output text)
+          
+          echo "instance_id=${INSTANCE_ID}" >> $GITHUB_OUTPUT
+          echo "Launched instance: ${INSTANCE_ID}"
+          
+          echo "Waiting for instance to be running..."
+          aws ec2 wait instance-running --instance-ids "${INSTANCE_ID}"
+          
+          echo "Waiting for status checks..."
+          aws ec2 wait instance-status-ok --instance-ids "${INSTANCE_ID}"
+          
+          PUBLIC_IP=$(aws ec2 describe-instances \
+            --instance-ids "${INSTANCE_ID}" \
+            --query 'Reservations[0].Instances[0].PublicIpAddress' \
+            --output text)
+          
+          echo "public_ip=${PUBLIC_IP}" >> $GITHUB_OUTPUT
+          echo "Instance ready at: ${PUBLIC_IP}"
+      
+      - name: Wait for SSH
+        run: |
+          echo "Waiting for SSH..."
+          for i in {1..30}; do
+            if ssh -i /tmp/eif-builder-key.pem \
+                   -o StrictHostKeyChecking=no \
+                   -o ConnectTimeout=5 \
+                   ec2-user@${{ steps.launch-instance.outputs.public_ip }} \
+                   'echo Ready' 2>/dev/null; then
+              echo "SSH is ready!"
+              break
+            fi
+            echo "Attempt $i/30, waiting 10s..."
+            sleep 10
+          done
+      
+      - name: Copy scripts to instance
+        run: |
+          scp -i /tmp/eif-builder-key.pem \
+              -o StrictHostKeyChecking=no \
+              -r enclave/scripts \
+              ec2-user@${{ steps.launch-instance.outputs.public_ip }}:~/
+      
+      - name: Setup Nitro instance
+        run: |
+          ssh -i /tmp/eif-builder-key.pem \
+              -o StrictHostKeyChecking=no \
+              ec2-user@${{ steps.launch-instance.outputs.public_ip }} \
+              'sudo bash ~/scripts/setup-nitro-instance.sh'
+      
+      - name: Build EIF
+        run: |
+          ssh -i /tmp/eif-builder-key.pem \
+              -o StrictHostKeyChecking=no \
+              ec2-user@${{ steps.launch-instance.outputs.public_ip }} \
+              "sudo AWS_ACCESS_KEY_ID='${AWS_ACCESS_KEY_ID}' \
+                    AWS_SECRET_ACCESS_KEY='${AWS_SECRET_ACCESS_KEY}' \
+                    AWS_SESSION_TOKEN='${AWS_SESSION_TOKEN}' \
+                    bash ~/scripts/build-eif-ci.sh \
+                    '${{ steps.image-uri.outputs.image_uri }}' \
+                    '/tmp/auction.eif' \
+                    '${{ env.AWS_REGION }}'"
+      
+      - name: Download EIF and measurements
+        run: |
+          scp -i /tmp/eif-builder-key.pem \
+              -o StrictHostKeyChecking=no \
+              ec2-user@${{ steps.launch-instance.outputs.public_ip }}:/tmp/auction.eif \
+              ./auction.eif
+          
+          scp -i /tmp/eif-builder-key.pem \
+              -o StrictHostKeyChecking=no \
+              ec2-user@${{ steps.launch-instance.outputs.public_ip }}:/tmp/auction.eif.measurements.json \
+              ./measurements.json
+      
+      - name: Extract PCRs
+        id: extract-pcrs
+        run: |
+          PCR0=$(jq -r '.Measurements.PCR0' measurements.json)
+          PCR1=$(jq -r '.Measurements.PCR1' measurements.json)
+          PCR2=$(jq -r '.Measurements.PCR2' measurements.json)
+          EIF_SHA256=$(sha256sum auction.eif | cut -d' ' -f1)
+          
+          echo "pcr0=${PCR0}" >> $GITHUB_OUTPUT
+          echo "pcr1=${PCR1}" >> $GITHUB_OUTPUT
+          echo "pcr2=${PCR2}" >> $GITHUB_OUTPUT
+          echo "eif_sha256=${EIF_SHA256}" >> $GITHUB_OUTPUT
+      
+      - name: Install ORAS
+        run: |
+          VERSION="1.1.0"
+          curl -LO "https://github.com/oras-project/oras/releases/download/v${VERSION}/oras_${VERSION}_linux_amd64.tar.gz"
+          tar -zxf oras_${VERSION}_*.tar.gz
+          sudo mv oras /usr/local/bin/
+          oras version
+      
+      - name: Login to ECR
+        run: |
+          aws ecr get-login-password --region ${{ env.AWS_REGION }} | \
+            oras login --username AWS --password-stdin \
+              ${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${{ env.AWS_REGION }}.amazonaws.com
+      
+      - name: Push EIF to ECR
+        run: |
+          COMMIT_SHA="${{ steps.set-sha.outputs.commit_sha }}"
+          COMMIT_SHORT="${{ steps.set-sha.outputs.commit_short }}"
+          REGISTRY="${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${{ env.AWS_REGION }}.amazonaws.com"
+          REPO="cloudx-io/openauction/enclave-eif"
+          
+          oras push "${REGISTRY}/${REPO}:sha-${COMMIT_SHA}" \
+            --artifact-type application/vnd.aws.nitro.eif \
+            --annotation "org.opencontainers.image.created=$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+            --annotation "org.opencontainers.image.revision=${COMMIT_SHA}" \
+            --annotation "com.aws.nitro.pcr0=${{ steps.extract-pcrs.outputs.pcr0 }}" \
+            --annotation "com.aws.nitro.pcr1=${{ steps.extract-pcrs.outputs.pcr1 }}" \
+            --annotation "com.aws.nitro.pcr2=${{ steps.extract-pcrs.outputs.pcr2 }}" \
+            auction.eif:application/octet-stream \
+            measurements.json:application/json
+          
+          if [ "${{ github.ref }}" = "refs/heads/main" ]; then
+            oras tag "${REGISTRY}/${REPO}:sha-${COMMIT_SHA}" latest
+          fi
+          
+          oras tag "${REGISTRY}/${REPO}:sha-${COMMIT_SHA}" "sha-${COMMIT_SHORT}"
+      
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: eif-${{ steps.set-sha.outputs.commit_short }}
+          path: |
+            auction.eif
+            measurements.json
+          retention-days: 90
+      
+      - name: Summary
+        run: |
+          cat >> $GITHUB_STEP_SUMMARY << 'EOF'
+          # EIF Build Complete ✅
+          
+          ## PCR Measurements
+          | PCR | Value |
+          |-----|-------|
+          | PCR0 | `${{ steps.extract-pcrs.outputs.pcr0 }}` |
+          | PCR1 | `${{ steps.extract-pcrs.outputs.pcr1 }}` |
+          | PCR2 | `${{ steps.extract-pcrs.outputs.pcr2 }}` |
+          
+          ## Artifact
+          - SHA256: `${{ steps.extract-pcrs.outputs.eif_sha256 }}`
+          - Commit: `${{ steps.set-sha.outputs.commit_sha }}`
+          EOF
+      
+      - name: Cleanup instance
+        if: always()
+        run: |
+          if [ -n "${{ steps.launch-instance.outputs.instance_id }}" ]; then
+            aws ec2 terminate-instances \
+              --instance-ids "${{ steps.launch-instance.outputs.instance_id }}"
+          fi
+      
+      - name: Cleanup security group
+        if: always()
+        run: |
+          if [ -n "${{ steps.security-group.outputs.security_group_id }}" ]; then
+            sleep 10
+            aws ec2 delete-security-group \
+              --group-id "${{ steps.security-group.outputs.security_group_id }}" || true
+          fi
+      
+      - name: Cleanup key pair
+        if: always()
+        run: |
+          if [ -n "${{ steps.create-key.outputs.key_name }}" ]; then
+            aws ec2 delete-key-pair \
+              --key-name "${{ steps.create-key.outputs.key_name }}"
+          fi
+          rm -f /tmp/eif-builder-key.pem

--- a/.github/workflows/eif-build.yml
+++ b/.github/workflows/eif-build.yml
@@ -1,5 +1,5 @@
 name: Build EIF
-run-name: Build EIF - ${{ github.event.workflow_run.head_sha }}
+run-name: Build EIF - commit ${{ github.event.workflow_run.head_sha || github.sha }} from image ${{ github.event.inputs.image_tag || 'auto' }}
 
 # This workflow builds Enclave Image Files (EIFs) for AWS Nitro Enclaves
 # EIFs can only be built on Nitro-compatible EC2 instances, so this workflow:
@@ -32,6 +32,12 @@ on:
     types: [completed]
     branches: [main]
   workflow_dispatch:
+    inputs:
+      image_tag:
+        description: 'Docker image tag to use (e.g., sha-abc1234, latest). Image must exist in ECR.'
+        required: true
+        default: 'latest'
+        type: string
 
 env:
   AWS_REGION: us-east-1
@@ -91,8 +97,18 @@ jobs:
       - name: Construct Docker image URI
         id: image-uri
         run: |
-          COMMIT_SHA="${{ steps.set-sha.outputs.commit_sha }}"
-          IMAGE_URI="${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${{ env.AWS_REGION }}.amazonaws.com/cloudx-io/openauction/enclave:sha-${COMMIT_SHA}"
+          # For workflow_run: use commit SHA from triggering workflow
+          # For workflow_dispatch: use user-provided image tag
+          if [ -n "${{ github.event.inputs.image_tag }}" ]; then
+            IMAGE_TAG="${{ github.event.inputs.image_tag }}"
+            echo "Using manually specified image tag: ${IMAGE_TAG}"
+          else
+            COMMIT_SHA="${{ steps.set-sha.outputs.commit_sha }}"
+            IMAGE_TAG="sha-${COMMIT_SHA}"
+            echo "Using commit-based image tag: ${IMAGE_TAG}"
+          fi
+
+          IMAGE_URI="${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${{ env.AWS_REGION }}.amazonaws.com/cloudx-io/openauction/enclave:${IMAGE_TAG}"
           echo "image_uri=${IMAGE_URI}" >> $GITHUB_OUTPUT
           echo "Docker image: ${IMAGE_URI}"
       
@@ -301,6 +317,10 @@ jobs:
           cat >> $GITHUB_STEP_SUMMARY << 'EOF'
           # EIF Build Complete ✅
           
+          ## Build Information
+          - Docker Image: `${{ steps.image-uri.outputs.image_uri }}`
+          - Commit: `${{ steps.set-sha.outputs.commit_sha }}`
+
           ## PCR Measurements
           | PCR | Value |
           |-----|-------|
@@ -308,9 +328,8 @@ jobs:
           | PCR1 | `${{ steps.extract-pcrs.outputs.pcr1 }}` |
           | PCR2 | `${{ steps.extract-pcrs.outputs.pcr2 }}` |
           
-          ## Artifact
+          ## EIF Artifact
           - SHA256: `${{ steps.extract-pcrs.outputs.eif_sha256 }}`
-          - Commit: `${{ steps.set-sha.outputs.commit_sha }}`
           EOF
       
       - name: Cleanup instance

--- a/enclave/scripts/build-eif-ci.sh
+++ b/enclave/scripts/build-eif-ci.sh
@@ -1,0 +1,203 @@
+#!/bin/bash
+set -euo pipefail
+
+# CI-optimized EIF build script for GitHub Actions
+# This script builds an Enclave Image File (EIF) from a Docker container image
+# on an AWS Nitro-compatible EC2 instance.
+#
+# Usage: build-eif-ci.sh <DOCKER_IMAGE_URI> <OUTPUT_EIF_PATH> [AWS_REGION]
+#
+# Arguments:
+#   DOCKER_IMAGE_URI: Full URI of the Docker image in ECR
+#   OUTPUT_EIF_PATH: Path where the EIF file should be written
+#   AWS_REGION: (Optional) AWS region, defaults to us-east-1
+#
+# Environment Variables:
+#   AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_SESSION_TOKEN: AWS credentials
+#
+# Outputs:
+#   - EIF file at OUTPUT_EIF_PATH
+#   - PCR measurements JSON at OUTPUT_EIF_PATH.measurements.json
+#   - PCR measurements to stdout for GitHub Actions
+
+# Parse arguments
+if [ $# -lt 2 ]; then
+    echo "ERROR: Missing required arguments"
+    echo "Usage: $0 <DOCKER_IMAGE_URI> <OUTPUT_EIF_PATH> [AWS_REGION]"
+    exit 1
+fi
+
+IMAGE_URI="$1"
+EIF_FILE="$2"
+AWS_REGION="${3:-${AWS_REGION:-us-east-1}}"
+
+# Create output directory if it doesn't exist
+EIF_DIR=$(dirname "$EIF_FILE")
+mkdir -p "$EIF_DIR"
+
+log() {
+    echo "[$(date '+%Y-%m-%d %H:%M:%S')] $*"
+}
+
+log_error() {
+    echo "[$(date '+%Y-%m-%d %H:%M:%S')] ERROR: $*" >&2
+}
+
+cleanup_on_failure() {
+    log_error "EIF builder failed - cleaning up"
+    docker system prune -f 2> /dev/null || true
+    exit 1
+}
+
+validate_prerequisites() {
+    log "Validating prerequisites..."
+    
+    if ! command -v aws &> /dev/null; then
+        log_error "AWS CLI not found - required for ECR authentication"
+        return 1
+    fi
+    log "✓ AWS CLI available: $(aws --version | head -n1)"
+
+    if ! command -v docker &> /dev/null; then
+        log_error "Docker not found - required for image operations"
+        return 1
+    fi
+    log "✓ Docker available: $(docker --version)"
+
+    if ! command -v nitro-cli &> /dev/null; then
+        log_error "Nitro CLI not found - required for EIF building"
+        return 1
+    fi
+    log "✓ Nitro CLI available: $(nitro-cli --version 2>&1 | head -n1 || echo 'version unknown')"
+
+    if ! aws sts get-caller-identity &> /dev/null; then
+        log_error "AWS credentials not configured"
+        log_error "Set AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY or attach IAM instance profile"
+        return 1
+    fi
+    log "✓ AWS credentials configured"
+}
+
+# Set up error handling
+trap cleanup_on_failure ERR
+
+main() {
+    log "========================================="
+    log "CloudX Nitro Enclave EIF Builder (CI)"
+    log "========================================="
+    log "Docker Image: $IMAGE_URI"
+    log "Output EIF: $EIF_FILE"
+    log "AWS Region: $AWS_REGION"
+    log "========================================="
+
+    validate_prerequisites
+
+    # Extract account ID from ECR URI
+    local account_id
+    account_id=$(echo "$IMAGE_URI" | cut -d'.' -f1)
+    local ecr_endpoint="${account_id}.dkr.ecr.${AWS_REGION}.amazonaws.com"
+    
+    log "ECR Endpoint: $ecr_endpoint"
+
+    # Authenticate to ECR
+    log "Authenticating to ECR..."
+    if ! aws ecr get-login-password --region "$AWS_REGION" | docker login --username AWS --password-stdin "$ecr_endpoint" 2>&1 | grep -i "login succeeded"; then
+        log_error "Failed to authenticate to ECR"
+        return 1
+    fi
+    log "✓ ECR authentication successful"
+
+    # Pull the Docker image
+    log "Pulling Docker image: $IMAGE_URI"
+    if ! docker pull "$IMAGE_URI"; then
+        log_error "Failed to pull Docker image: $IMAGE_URI"
+        log_error "Verify the image exists and credentials are correct"
+        return 1
+    fi
+    log "✓ Docker image pulled successfully"
+
+    # Build EIF from Docker image
+    log "Building EIF from Docker image..."
+    
+    local build_output="/tmp/nitro-build-output.json"
+    if ! nitro-cli build-enclave \
+        --docker-uri "$IMAGE_URI" \
+        --output-file "$EIF_FILE" \
+        > "$build_output" 2>&1; then
+        log_error "Failed to build EIF from Docker image"
+        if [ -f "$build_output" ]; then
+            log_error "Build output:"
+            cat "$build_output" >&2
+        fi
+        return 1
+    fi
+
+    # Verify EIF was created
+    if [ ! -f "$EIF_FILE" ]; then
+        log_error "EIF file not created: $EIF_FILE"
+        return 1
+    fi
+
+    local eif_size
+    eif_size=$(du -h "$EIF_FILE" | cut -f1)
+    log "✓ EIF created successfully"
+    log "  File: $EIF_FILE"
+    log "  Size: $eif_size"
+
+    # Extract and save PCR measurements
+    log "Extracting PCR measurements..."
+    
+    local measurements_file="${EIF_FILE}.measurements.json"
+    
+    # Parse the nitro-cli output and extract measurements
+    if command -v jq > /dev/null 2>&1 && [ -f "$build_output" ]; then
+        # Pretty-print to measurements file
+        cat "$build_output" | jq '.' > "$measurements_file" 2>/dev/null || {
+            log_error "Failed to parse PCR measurements with jq"
+            cat "$build_output" > "$measurements_file"
+        }
+        
+        # Extract key measurements
+        local pcr0 pcr1 pcr2
+        pcr0=$(cat "$build_output" | jq -r '.Measurements.PCR0 // "unknown"' 2>/dev/null || echo "unknown")
+        pcr1=$(cat "$build_output" | jq -r '.Measurements.PCR1 // "unknown"' 2>/dev/null || echo "unknown")
+        pcr2=$(cat "$build_output" | jq -r '.Measurements.PCR2 // "unknown"' 2>/dev/null || echo "unknown")
+        
+        log "PCR Measurements:"
+        log "  PCR0: $pcr0"
+        log "  PCR1: $pcr1"
+        log "  PCR2: $pcr2"
+        
+        # Output for GitHub Actions (can be captured)
+        echo "PCR0=$pcr0"
+        echo "PCR1=$pcr1"
+        echo "PCR2=$pcr2"
+        
+    else
+        log "jq not available, saving raw output"
+        cat "$build_output" > "$measurements_file"
+        log "Raw PCR measurements saved to: $measurements_file"
+    fi
+
+    log "✓ PCR measurements saved to: $measurements_file"
+
+    # Cleanup Docker resources to free space
+    log "Cleaning up Docker resources..."
+    docker rmi "$IMAGE_URI" 2> /dev/null || true
+    docker system prune -f 2> /dev/null || true
+    log "✓ Cleanup complete"
+
+    log "========================================="
+    log "EIF Build Complete!"
+    log "========================================="
+    log "EIF File: $EIF_FILE"
+    log "Size: $eif_size"
+    log "Measurements: $measurements_file"
+    log "========================================="
+
+    return 0
+}
+
+# Run main function
+main "$@"
+

--- a/enclave/scripts/setup-nitro-instance.sh
+++ b/enclave/scripts/setup-nitro-instance.sh
@@ -1,0 +1,254 @@
+#!/bin/bash
+set -euo pipefail
+
+# Setup script for AWS Nitro-compatible EC2 instances
+# Prepares an instance for building Enclave Image Files (EIFs)
+#
+# Usage: setup-nitro-instance.sh
+#
+# Requirements:
+#   - Amazon Linux 2023 or compatible OS
+#   - Nitro-compatible EC2 instance type (c5, m5, r5, etc.)
+#   - Root or sudo access
+#
+# This script installs:
+#   - AWS Nitro Enclaves CLI
+#   - Docker (if not already installed)
+#   - jq for JSON processing
+#   - Configures Nitro Enclaves allocator
+
+log() {
+    echo "[$(date '+%Y-%m-%d %H:%M:%S')] $*"
+}
+
+log_error() {
+    echo "[$(date '+%Y-%m-%d %H:%M:%S')] ERROR: $*" >&2
+}
+
+check_os() {
+    log "Checking operating system..."
+    
+    if [ -f /etc/os-release ]; then
+        . /etc/os-release
+        log "Detected OS: $NAME $VERSION"
+        
+        # Check if Amazon Linux 2023
+        if [[ "$ID" == "amzn" && "$VERSION_ID" == "2023" ]]; then
+            log "✓ Amazon Linux 2023 detected"
+            return 0
+        elif [[ "$ID" == "amzn" ]]; then
+            log "Amazon Linux detected (version: $VERSION_ID)"
+            return 0
+        else
+            log "Warning: This script is optimized for Amazon Linux 2023"
+            log "Detected: $NAME $VERSION"
+            log "Continuing anyway..."
+            return 0
+        fi
+    else
+        log_error "Cannot determine OS version"
+        return 1
+    fi
+}
+
+install_nitro_cli() {
+    log "Installing AWS Nitro Enclaves CLI..."
+    
+    if command -v nitro-cli &> /dev/null; then
+        log "Nitro CLI already installed: $(nitro-cli --version 2>&1 | head -n1 || echo 'version unknown')"
+        return 0
+    fi
+    
+    # Install from Amazon Linux repository
+    if command -v dnf &> /dev/null; then
+        sudo dnf install -y aws-nitro-enclaves-cli aws-nitro-enclaves-cli-devel
+    elif command -v yum &> /dev/null; then
+        sudo yum install -y aws-nitro-enclaves-cli aws-nitro-enclaves-cli-devel
+    else
+        log_error "Package manager not found (dnf or yum required)"
+        return 1
+    fi
+    
+    if command -v nitro-cli &> /dev/null; then
+        log "✓ Nitro CLI installed: $(nitro-cli --version 2>&1 | head -n1 || echo 'installed')"
+    else
+        log_error "Nitro CLI installation failed"
+        return 1
+    fi
+}
+
+install_docker() {
+    log "Checking Docker installation..."
+    
+    if command -v docker &> /dev/null; then
+        log "Docker already installed: $(docker --version)"
+        return 0
+    fi
+    
+    log "Installing Docker..."
+    
+    if command -v dnf &> /dev/null; then
+        sudo dnf install -y docker
+    elif command -v yum &> /dev/null; then
+        sudo yum install -y docker
+    else
+        log_error "Package manager not found (dnf or yum required)"
+        return 1
+    fi
+    
+    # Start Docker service
+    sudo systemctl start docker
+    sudo systemctl enable docker
+    
+    # Add current user to docker group (if not root)
+    if [ "$EUID" -ne 0 ]; then
+        sudo usermod -aG docker "$USER" || true
+        log "Note: You may need to log out and back in for docker group changes to take effect"
+    fi
+    
+    log "✓ Docker installed: $(docker --version)"
+}
+
+install_dependencies() {
+    log "Installing additional dependencies..."
+    
+    local packages=("jq" "curl" "awscli")
+    
+    for pkg in "${packages[@]}"; do
+        if ! command -v "$pkg" &> /dev/null; then
+            log "Installing $pkg..."
+            if command -v dnf &> /dev/null; then
+                sudo dnf install -y "$pkg"
+            elif command -v yum &> /dev/null; then
+                sudo yum install -y "$pkg"
+            fi
+        else
+            log "✓ $pkg already installed"
+        fi
+    done
+}
+
+configure_nitro_allocator() {
+    log "Configuring Nitro Enclaves allocator..."
+    
+    # Create allocator config directory
+    sudo mkdir -p /etc/nitro_enclaves
+    
+    # Create allocator configuration
+    # Allocate memory and CPUs for enclave building
+    # These are conservative values suitable for c5.xlarge and similar instances
+    cat << 'EOF' | sudo tee /etc/nitro_enclaves/allocator.yaml > /dev/null
+---
+# Enclave memory in MiB (6GB for EIF building)
+memory_mib: 6144
+
+# Number of vCPUs to allocate (2 CPUs for building)
+cpu_count: 2
+
+# CPU pool configuration
+# 0 = dedicated for enclave
+cpu_pool: 0
+EOF
+    
+    log "✓ Allocator configuration created"
+    
+    # Enable and start allocator service
+    if systemctl list-unit-files | grep -q nitro-enclaves-allocator; then
+        log "Enabling nitro-enclaves-allocator service..."
+        sudo systemctl enable nitro-enclaves-allocator.service
+        sudo systemctl start nitro-enclaves-allocator.service
+        
+        # Wait a moment for service to stabilize
+        sleep 2
+        
+        if systemctl is-active --quiet nitro-enclaves-allocator; then
+            log "✓ Nitro Enclaves allocator service running"
+        else
+            log "Warning: Allocator service not running (may need Nitro-compatible instance)"
+            log "This is normal on non-Nitro instances or in virtualized environments"
+        fi
+    else
+        log "Warning: nitro-enclaves-allocator service not found"
+        log "This is normal on non-Nitro instances"
+    fi
+}
+
+verify_setup() {
+    log "Verifying setup..."
+    
+    local all_good=true
+    
+    # Check nitro-cli
+    if command -v nitro-cli &> /dev/null; then
+        log "✓ nitro-cli: $(nitro-cli --version 2>&1 | head -n1 || echo 'installed')"
+    else
+        log_error "✗ nitro-cli not found"
+        all_good=false
+    fi
+    
+    # Check Docker
+    if command -v docker &> /dev/null; then
+        log "✓ docker: $(docker --version)"
+    else
+        log_error "✗ docker not found"
+        all_good=false
+    fi
+    
+    # Check jq
+    if command -v jq &> /dev/null; then
+        log "✓ jq: $(jq --version)"
+    else
+        log "Warning: jq not found (recommended for PCR parsing)"
+    fi
+    
+    # Check AWS CLI
+    if command -v aws &> /dev/null; then
+        log "✓ aws-cli: $(aws --version 2>&1 | head -n1)"
+    else
+        log_error "✗ aws-cli not found"
+        all_good=false
+    fi
+    
+    # Check allocator config
+    if [ -f /etc/nitro_enclaves/allocator.yaml ]; then
+        log "✓ allocator.yaml configured"
+    else
+        log_error "✗ allocator.yaml not found"
+        all_good=false
+    fi
+    
+    if [ "$all_good" = true ]; then
+        log "========================================="
+        log "✓ Setup complete!"
+        log "========================================="
+        log "Instance is ready for EIF building"
+        log "Run build-eif-ci.sh to build an EIF"
+        return 0
+    else
+        log_error "========================================="
+        log_error "Setup incomplete - check errors above"
+        log_error "========================================="
+        return 1
+    fi
+}
+
+main() {
+    log "========================================="
+    log "Nitro Instance Setup for EIF Building"
+    log "========================================="
+    
+    check_os
+    install_nitro_cli
+    install_docker
+    install_dependencies
+    configure_nitro_allocator
+    verify_setup
+    
+    log "========================================="
+    log "Setup script completed"
+    log "========================================="
+}
+
+# Run main function
+main "$@"
+


### PR DESCRIPTION
## Summary

Add GitHub Actions workflow to build Enclave Image Files (EIFs) on ephemeral Nitro EC2 instances and push them to ECR as artifacts. This enables reproducible builds and third-party PCR verification.

This will run for the first time after merging to `main`. Once the new Github workflow is in `main`, it will be easy to iterate by dispatching the workflow from a feature branch.

## How It Works

```
Docker Build (main) → EIF Build Workflow Triggers → Launch Nitro EC2 → Build EIF → Push to ECR → Terminate EC2
```

EIF artifacts are stored in ECR with PCR measurements as OCI annotations. Anyone can fork the repo, run the workflow, and verify PCR values match.

## Dependencies

Requires IAM roles (created separately):
- `eif-builder-workflow` - OIDC role for GitHub Actions runner
- `eif-builder-instance` - Instance profile for EC2 instances

ECR repository `cloudx-io/openauction/enclave-eif` must exist.

## Testing

Workflow can be tested via:
1. Push to main (auto-triggers after Docker build)
2. Manual dispatch from Actions UI (select any branch)

After merge, verify by checking workflow run and comparing PCR values. Any issues will be fixed forward.