### PR TITLE
add validation for auction attestations

### DIFF
--- a/core/hash.go
+++ b/core/hash.go
@@ -1,0 +1,67 @@
+package core
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"sort"
+)
+
+// ComputeBidHash computes the bid hash using the TEE algorithm.
+// This is used by both the enclave (to generate hashes) and validation (to verify hashes).
+//
+// Formula: SHA256(bid_id + "|" + sprintf("%.6f", price) + "|" + nonce)
+//
+// The price is formatted to exactly 6 decimal places to ensure consistent hashing
+// regardless of how the float is represented in memory.
+func ComputeBidHash(bidID string, price float64, nonce string) string {
+	data := fmt.Sprintf("%s|%.6f|%s", bidID, price, nonce)
+	hash := sha256.Sum256([]byte(data))
+	return fmt.Sprintf("%x", hash)
+}
+
+// ComputeBidHashEncrypted computes the bid hash for encrypted bids using the TEE algorithm.
+// For encrypted bids, we hash the encrypted payload instead of the price since only the TEE
+// can decrypt the price. This allows bidders to verify their encrypted bid was included without
+// needing the TEE's private key.
+//
+// Formula: SHA256(bid_id + "|" + encrypted_payload + "|" + nonce)
+func ComputeBidHashEncrypted(bidID string, encryptedPayload string, nonce string) string {
+	data := fmt.Sprintf("%s|%s|%s", bidID, encryptedPayload, nonce)
+	hash := sha256.Sum256([]byte(data))
+	return fmt.Sprintf("%x", hash)
+}
+
+// ComputeRequestHash computes the auction request hash using the TEE algorithm.
+// This is used by both the enclave (to generate hashes) and validation (to verify hashes).
+//
+// Formula: SHA256(auction_id + "|" + round_id + "|" + nonce)
+func ComputeRequestHash(auctionID string, roundID int, nonce string) string {
+	data := fmt.Sprintf("%s|%d|%s", auctionID, roundID, nonce)
+	hash := sha256.Sum256([]byte(data))
+	return fmt.Sprintf("%x", hash)
+}
+
+// ComputeAdjustmentFactorsHash computes the adjustment factors hash using the TEE algorithm.
+// This is used by both the enclave (to generate hashes) and validation (to verify hashes).
+//
+// Formula: SHA256(nonce + "|" + sorted_key_value_pairs)
+// where sorted_key_value_pairs = "bidder1:factor1|bidder2:factor2|..." (sorted by bidder name)
+//
+// Factors are formatted to exactly 6 decimal places for consistent hashing.
+func ComputeAdjustmentFactorsHash(adjustmentFactors map[string]float64, nonce string) string {
+	data := nonce
+
+	// Sort bidders to ensure deterministic hash calculation
+	bidders := make([]string, 0, len(adjustmentFactors))
+	for bidder := range adjustmentFactors {
+		bidders = append(bidders, bidder)
+	}
+	sort.Strings(bidders)
+
+	for _, bidder := range bidders {
+		factor := adjustmentFactors[bidder]
+		data += fmt.Sprintf("|%s:%.6f", bidder, factor)
+	}
+	hash := sha256.Sum256([]byte(data))
+	return fmt.Sprintf("%x", hash)
+}

--- a/core/hash_test.go
+++ b/core/hash_test.go
@@ -20,7 +20,7 @@ func TestComputeBidHash(t *testing.T) {
 
 	// Verify hash contains only hex characters
 	for _, c := range hash {
-		if !((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f')) {
+		if (c < '0' || c > '9') && (c < 'a' || c > 'f') {
 			t.Errorf("ComputeBidHash() contains non-hex character: %c", c)
 		}
 	}
@@ -125,7 +125,7 @@ func TestComputeBidHash_EdgeCases(t *testing.T) {
 
 			// Verify hash contains only hex characters
 			for _, c := range hash {
-				if !((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f')) {
+				if (c < '0' || c > '9') && (c < 'a' || c > 'f') {
 					t.Errorf("Hash contains non-hex character: %c", c)
 				}
 			}
@@ -147,7 +147,7 @@ func TestComputeRequestHash(t *testing.T) {
 
 	// Verify hash contains only hex characters
 	for _, c := range hash {
-		if !((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f')) {
+		if (c < '0' || c > '9') && (c < 'a' || c > 'f') {
 			t.Errorf("ComputeRequestHash() contains non-hex character: %c", c)
 		}
 	}
@@ -199,7 +199,7 @@ func TestComputeAdjustmentFactorsHash(t *testing.T) {
 
 	// Verify hash contains only hex characters
 	for _, c := range hash {
-		if !((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f')) {
+		if (c < '0' || c > '9') && (c < 'a' || c > 'f') {
 			t.Errorf("ComputeAdjustmentFactorsHash() contains non-hex character: %c", c)
 		}
 	}
@@ -282,7 +282,7 @@ func TestComputeBidHashEncrypted(t *testing.T) {
 
 	// Verify hash contains only hex characters
 	for _, c := range hash {
-		if !((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f')) {
+		if (c < '0' || c > '9') && (c < 'a' || c > 'f') {
 			t.Errorf("ComputeBidHashEncrypted() contains non-hex character: %c", c)
 		}
 	}

--- a/core/hash_test.go
+++ b/core/hash_test.go
@@ -1,0 +1,323 @@
+package core
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"testing"
+)
+
+func TestComputeBidHash(t *testing.T) {
+	bidID := "bid_123"
+	price := 2.50
+	nonce := "test_nonce_456"
+
+	hash := ComputeBidHash(bidID, price, nonce)
+
+	// Verify hash is 64 characters (SHA256 hex encoding)
+	if len(hash) != 64 {
+		t.Errorf("ComputeBidHash() hash length = %d, want 64", len(hash))
+	}
+
+	// Verify hash contains only hex characters
+	for _, c := range hash {
+		if !((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f')) {
+			t.Errorf("ComputeBidHash() contains non-hex character: %c", c)
+		}
+	}
+
+	// Same inputs should produce same hash (deterministic)
+	hash2 := ComputeBidHash(bidID, price, nonce)
+	if hash != hash2 {
+		t.Errorf("ComputeBidHash() not deterministic")
+	}
+
+	// Different inputs should produce different hashes
+	hash3 := ComputeBidHash(bidID, price+1, nonce)
+	if hash == hash3 {
+		t.Errorf("Different inputs should produce different hashes")
+	}
+
+	// Verify exact hash calculation
+	expectedData := fmt.Sprintf("%s|%.6f|%s", bidID, price, nonce)
+	expectedHash := fmt.Sprintf("%x", sha256.Sum256([]byte(expectedData)))
+	if hash != expectedHash {
+		t.Errorf("ComputeBidHash() = %v, want %v", hash, expectedHash)
+	}
+}
+
+func TestComputeBidHash_PriceFormatting(t *testing.T) {
+	// Test that price is formatted to exactly 6 decimal places
+	nonce := "test"
+
+	// These should produce the same hash because they're the same to 6 decimal places
+	hash1 := ComputeBidHash("bid-1", 2.123456, nonce)
+	hash2 := ComputeBidHash("bid-1", 2.1234560, nonce)
+	hash3 := ComputeBidHash("bid-1", 2.12345600000, nonce)
+
+	if hash1 != hash2 || hash1 != hash3 {
+		t.Errorf("Prices with same 6 decimal places should produce same hash")
+	}
+
+	// These should produce different hashes (differ in 6th decimal)
+	hash4 := ComputeBidHash("bid-1", 2.123456, nonce)
+	hash5 := ComputeBidHash("bid-1", 2.123457, nonce)
+
+	if hash4 == hash5 {
+		t.Errorf("Prices with different 6th decimal should produce different hashes")
+	}
+}
+
+func TestComputeBidHash_DifferentInputs(t *testing.T) {
+	nonce := "test-nonce"
+
+	// Different bid IDs should produce different hashes
+	hash1 := ComputeBidHash("bid-1", 2.50, nonce)
+	hash2 := ComputeBidHash("bid-2", 2.50, nonce)
+	if hash1 == hash2 {
+		t.Errorf("Different bid IDs should produce different hashes")
+	}
+
+	// Different prices should produce different hashes
+	hash3 := ComputeBidHash("bid-1", 2.50, nonce)
+	hash4 := ComputeBidHash("bid-1", 2.51, nonce)
+	if hash3 == hash4 {
+		t.Errorf("Different prices should produce different hashes")
+	}
+
+	// Different nonces should produce different hashes
+	hash5 := ComputeBidHash("bid-1", 2.50, "nonce-1")
+	hash6 := ComputeBidHash("bid-1", 2.50, "nonce-2")
+	if hash5 == hash6 {
+		t.Errorf("Different nonces should produce different hashes")
+	}
+}
+
+func TestComputeBidHash_EdgeCases(t *testing.T) {
+	testCases := []struct {
+		name  string
+		bidID string
+		price float64
+		nonce string
+	}{
+		{"zero price", "bid-1", 0.0, "nonce"},
+		{"high price", "bid-1", 999.999999, "nonce"},
+		{"many decimals", "bid-2", 1.234567891234, "nonce"},
+		{"negative price", "bid-3", -1.50, "nonce"},
+		{"empty bid ID", "", 2.50, "nonce"},
+		{"empty nonce", "bid-1", 2.50, ""},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			hash := ComputeBidHash(tc.bidID, tc.price, tc.nonce)
+
+			// Verify the hash is deterministic
+			hash2 := ComputeBidHash(tc.bidID, tc.price, tc.nonce)
+			if hash != hash2 {
+				t.Errorf("Hash not deterministic for bidID=%s, price=%f, nonce=%s",
+					tc.bidID, tc.price, tc.nonce)
+			}
+
+			// Verify hash format
+			if len(hash) != 64 {
+				t.Errorf("Hash has wrong length: got %d, want 64", len(hash))
+			}
+
+			// Verify hash contains only hex characters
+			for _, c := range hash {
+				if !((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f')) {
+					t.Errorf("Hash contains non-hex character: %c", c)
+				}
+			}
+		})
+	}
+}
+
+func TestComputeRequestHash(t *testing.T) {
+	auctionID := "auction-123"
+	roundID := 1
+	nonce := "test-nonce"
+
+	hash := ComputeRequestHash(auctionID, roundID, nonce)
+
+	// Verify hash is 64 characters (SHA256 hex encoding)
+	if len(hash) != 64 {
+		t.Errorf("ComputeRequestHash() hash length = %d, want 64", len(hash))
+	}
+
+	// Verify hash contains only hex characters
+	for _, c := range hash {
+		if !((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f')) {
+			t.Errorf("ComputeRequestHash() contains non-hex character: %c", c)
+		}
+	}
+
+	// Test determinism
+	hash2 := ComputeRequestHash(auctionID, roundID, nonce)
+	if hash != hash2 {
+		t.Errorf("ComputeRequestHash() not deterministic")
+	}
+
+	// Test that different inputs produce different hashes
+	hash3 := ComputeRequestHash(auctionID, roundID+1, nonce)
+	if hash == hash3 {
+		t.Errorf("Different round IDs should produce different hashes")
+	}
+
+	hash4 := ComputeRequestHash("different-auction", roundID, nonce)
+	if hash == hash4 {
+		t.Errorf("Different auction IDs should produce different hashes")
+	}
+
+	hash5 := ComputeRequestHash(auctionID, roundID, "different-nonce")
+	if hash == hash5 {
+		t.Errorf("Different nonces should produce different hashes")
+	}
+
+	// Verify exact hash calculation
+	expectedData := fmt.Sprintf("%s|%d|%s", auctionID, roundID, nonce)
+	expectedHash := fmt.Sprintf("%x", sha256.Sum256([]byte(expectedData)))
+	if hash != expectedHash {
+		t.Errorf("ComputeRequestHash() = %v, want %v", hash, expectedHash)
+	}
+}
+
+func TestComputeAdjustmentFactorsHash(t *testing.T) {
+	nonce := "test-nonce"
+	factors := map[string]float64{
+		"meta":     1.0,
+		"appnexus": 0.95,
+		"pubmatic": 1.15,
+	}
+
+	hash := ComputeAdjustmentFactorsHash(factors, nonce)
+
+	// Verify hash is 64 characters (SHA256 hex encoding)
+	if len(hash) != 64 {
+		t.Errorf("ComputeAdjustmentFactorsHash() hash length = %d, want 64", len(hash))
+	}
+
+	// Verify hash contains only hex characters
+	for _, c := range hash {
+		if !((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f')) {
+			t.Errorf("ComputeAdjustmentFactorsHash() contains non-hex character: %c", c)
+		}
+	}
+
+	// Test determinism
+	hash2 := ComputeAdjustmentFactorsHash(factors, nonce)
+	if hash != hash2 {
+		t.Errorf("ComputeAdjustmentFactorsHash() not deterministic")
+	}
+
+	// Test that different nonces produce different hashes
+	hash3 := ComputeAdjustmentFactorsHash(factors, "different-nonce")
+	if hash == hash3 {
+		t.Errorf("Different nonces should produce different hashes")
+	}
+
+	// Test that different factors produce different hashes
+	differentFactors := map[string]float64{
+		"meta":     1.0,
+		"appnexus": 0.96, // Different value
+		"pubmatic": 1.15,
+	}
+	hash4 := ComputeAdjustmentFactorsHash(differentFactors, nonce)
+	if hash == hash4 {
+		t.Errorf("Different adjustment factors should produce different hashes")
+	}
+}
+
+func TestComputeAdjustmentFactorsHash_Sorting(t *testing.T) {
+	nonce := "test"
+
+	// These should produce the same hash because they're the same factors, just in different map iteration order
+	factors1 := map[string]float64{"meta": 1.0, "appnexus": 0.95}
+	factors2 := map[string]float64{"appnexus": 0.95, "meta": 1.0}
+
+	hash1 := ComputeAdjustmentFactorsHash(factors1, nonce)
+	hash2 := ComputeAdjustmentFactorsHash(factors2, nonce)
+
+	if hash1 != hash2 {
+		t.Errorf("Same factors in different order should produce same hash due to sorting")
+	}
+
+	// Verify exact calculation with sorted keys
+	expectedData := "test|appnexus:0.950000|meta:1.000000"
+	expectedHash := fmt.Sprintf("%x", sha256.Sum256([]byte(expectedData)))
+	if hash1 != expectedHash {
+		t.Errorf("ComputeAdjustmentFactorsHash() = %v, want %v", hash1, expectedHash)
+	}
+}
+
+func TestComputeAdjustmentFactorsHash_EmptyMap(t *testing.T) {
+	nonce := "test-nonce"
+	emptyFactors := map[string]float64{}
+
+	hash := ComputeAdjustmentFactorsHash(emptyFactors, nonce)
+
+	// Verify hash is 64 characters
+	if len(hash) != 64 {
+		t.Errorf("ComputeAdjustmentFactorsHash() hash length = %d, want 64", len(hash))
+	}
+
+	// Empty map should produce hash of just the nonce
+	expectedHash := fmt.Sprintf("%x", sha256.Sum256([]byte(nonce)))
+	if hash != expectedHash {
+		t.Errorf("Empty map should hash just the nonce")
+	}
+}
+
+func TestComputeBidHashEncrypted(t *testing.T) {
+	bidID := "bid-123"
+	encryptedPayload := "fiiphOfYHw70adwG15VdAR5lHdez+wL4aYKFuYXJYYD0LpvmF9pZ+hIPdGzzpIUcz/1ZZ/5E/1Rg233u1DR4x0gKA49pa/AVi2aAGpT5qttV1m8N4k4="
+	nonce := "test-nonce"
+
+	hash := ComputeBidHashEncrypted(bidID, encryptedPayload, nonce)
+
+	// Verify hash is 64 characters (SHA256 hex encoding)
+	if len(hash) != 64 {
+		t.Errorf("ComputeBidHashEncrypted() hash length = %d, want 64", len(hash))
+	}
+
+	// Verify hash contains only hex characters
+	for _, c := range hash {
+		if !((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f')) {
+			t.Errorf("ComputeBidHashEncrypted() contains non-hex character: %c", c)
+		}
+	}
+
+	// Test determinism
+	hash2 := ComputeBidHashEncrypted(bidID, encryptedPayload, nonce)
+	if hash != hash2 {
+		t.Errorf("ComputeBidHashEncrypted() not deterministic")
+	}
+
+	// Test that different encrypted payloads produce different hashes
+	hash3 := ComputeBidHashEncrypted(bidID, "different_payload", nonce)
+	if hash == hash3 {
+		t.Errorf("Different encrypted payloads should produce different hashes")
+	}
+
+	// Verify exact hash calculation
+	expectedData := fmt.Sprintf("%s|%s|%s", bidID, encryptedPayload, nonce)
+	expectedHash := fmt.Sprintf("%x", sha256.Sum256([]byte(expectedData)))
+	if hash != expectedHash {
+		t.Errorf("ComputeBidHashEncrypted() = %v, want %v", hash, expectedHash)
+	}
+}
+
+func TestComputeBidHashEncrypted_VsUnencrypted(t *testing.T) {
+	bidID := "bid-123"
+	price := 99.99
+	encryptedPayload := "some_encrypted_data"
+	nonce := "test-nonce"
+
+	// Encrypted and unencrypted hashes should be different
+	hashUnencrypted := ComputeBidHash(bidID, price, nonce)
+	hashEncrypted := ComputeBidHashEncrypted(bidID, encryptedPayload, nonce)
+
+	if hashUnencrypted == hashEncrypted {
+		t.Errorf("Encrypted and unencrypted bid hashes should be different")
+	}
+}

--- a/enclave/auction_test.go
+++ b/enclave/auction_test.go
@@ -83,7 +83,7 @@ func TestProcessAuction_OneBid(t *testing.T) {
 
 	// Verify bid hashes contains single bid
 	nonce := attestationDoc.UserData.BidHashNonce
-	expectedHash := generateBidHash("bid1", 2.50, nonce)
+	expectedHash := core.ComputeBidHash("bid1", 2.50, nonce)
 
 	check.Equal(t, 1, len(attestationDoc.UserData.BidHashes))
 	check.True(t, slices.Contains(attestationDoc.UserData.BidHashes, expectedHash))
@@ -127,8 +127,8 @@ func TestProcessAuction_TwoBids(t *testing.T) {
 
 	// Verify bid hashes contains both bids
 	nonce := attestationDoc.UserData.BidHashNonce
-	hash1 := generateBidHash("bid1", 2.50, nonce)
-	hash2 := generateBidHash("bid2", 3.00, nonce)
+	hash1 := core.ComputeBidHash("bid1", 2.50, nonce)
+	hash2 := core.ComputeBidHash("bid2", 3.00, nonce)
 
 	check.Equal(t, 2, len(attestationDoc.UserData.BidHashes))
 	check.True(t, slices.Contains(attestationDoc.UserData.BidHashes, hash1))
@@ -177,9 +177,9 @@ func TestProcessAuction_ThreeBids(t *testing.T) {
 
 	// Verify bid hashes contains all three bids
 	nonce := attestationDoc.UserData.BidHashNonce
-	hash1 := generateBidHash("bid1", 2.50, nonce)
-	hash2 := generateBidHash("bid2", 3.00, nonce)
-	hash3 := generateBidHash("bid3", 2.25, nonce)
+	hash1 := core.ComputeBidHash("bid1", 2.50, nonce)
+	hash2 := core.ComputeBidHash("bid2", 3.00, nonce)
+	hash3 := core.ComputeBidHash("bid3", 2.25, nonce)
 
 	check.Equal(t, 3, len(attestationDoc.UserData.BidHashes))
 	check.True(t, slices.Contains(attestationDoc.UserData.BidHashes, hash1))

--- a/enclave/proofs.go
+++ b/enclave/proofs.go
@@ -22,7 +22,7 @@ type EnclaveAttester interface {
 	Attest(options enclave.AttestationOptions) ([]byte, error)
 }
 
-func GenerateTEEProofs(attester EnclaveAttester, req enclaveapi.EnclaveAuctionRequest, unencryptedBids []core.CoreBid, winner, runnerUp *core.CoreBid) (enclaveapi.AttestationCOSE, error) {
+func GenerateTEEProofs(attester EnclaveAttester, req enclaveapi.EnclaveAuctionRequest, _ []core.CoreBid, winner, runnerUp *core.CoreBid) (enclaveapi.AttestationCOSE, error) {
 	bidHashNonce, err := generateNonce()
 	if err != nil {
 		return nil, fmt.Errorf("failed to generate bid hash nonce: %w", err)

--- a/enclave/proofs.go
+++ b/enclave/proofs.go
@@ -3,14 +3,12 @@ package main
 import (
 	"crypto/rand"
 	"crypto/rsa"
-	"crypto/sha256"
 	"crypto/x509"
 	"encoding/hex"
 	"encoding/json"
 	"encoding/pem"
 	"fmt"
 	"log"
-	"sort"
 	"time"
 
 	enclave "github.com/edgebitio/nitro-enclaves-sdk-go"
@@ -40,10 +38,18 @@ func GenerateTEEProofs(attester EnclaveAttester, req enclaveapi.EnclaveAuctionRe
 		return nil, fmt.Errorf("failed to generate adjustment factors nonce: %w", err)
 	}
 
-	// Build list of bid hashes from unencrypted bid prices
-	bidHashes := make([]string, 0, len(unencryptedBids))
-	for _, bid := range unencryptedBids {
-		bidHashes = append(bidHashes, generateBidHash(bid.ID, bid.Price, bidHashNonce))
+	// Build list of bid hashes from original bids (use encrypted payload if encrypted, price if not)
+	bidHashes := make([]string, 0, len(req.Bids))
+	for _, bid := range req.Bids {
+		var hash string
+		if bid.EncryptedPrice != nil {
+			// For encrypted bids, hash the encrypted payload
+			hash = core.ComputeBidHashEncrypted(bid.ID, bid.EncryptedPrice.EncryptedPayload, bidHashNonce)
+		} else {
+			// For unencrypted bids, hash the price
+			hash = core.ComputeBidHash(bid.ID, bid.Price, bidHashNonce)
+		}
+		bidHashes = append(bidHashes, hash)
 	}
 
 	requestHash := calculateRequestHash(req, requestNonce)
@@ -74,34 +80,12 @@ func generateNonce() (string, error) {
 	return hex.EncodeToString(randomBytes), nil
 }
 
-func generateBidHash(bidID string, price float64, nonce string) string {
-	data := fmt.Sprintf("%s|%.6f|%s", bidID, price, nonce)
-	hash := sha256.Sum256([]byte(data))
-	return fmt.Sprintf("%x", hash)
-}
-
 func calculateRequestHash(req enclaveapi.EnclaveAuctionRequest, nonce string) string {
-	data := fmt.Sprintf("%s|%d|%s", req.AuctionID, req.RoundID, nonce)
-	hash := sha256.Sum256([]byte(data))
-	return fmt.Sprintf("%x", hash)
+	return core.ComputeRequestHash(req.AuctionID, req.RoundID, nonce)
 }
 
 func calculateAdjustmentFactorsHash(adjustmentFactors map[string]float64, nonce string) string {
-	data := nonce
-
-	// Sort bidders to ensure deterministic hash calculation
-	bidders := make([]string, 0, len(adjustmentFactors))
-	for bidder := range adjustmentFactors {
-		bidders = append(bidders, bidder)
-	}
-	sort.Strings(bidders)
-
-	for _, bidder := range bidders {
-		factor := adjustmentFactors[bidder]
-		data += fmt.Sprintf("|%s:%.6f", bidder, factor)
-	}
-	hash := sha256.Sum256([]byte(data))
-	return fmt.Sprintf("%x", hash)
+	return core.ComputeAdjustmentFactorsHash(adjustmentFactors, nonce)
 }
 
 // stripBidderName converts a CoreBid to CoreBidWithoutBidder, removing bidder identity

--- a/validation/attestation.go
+++ b/validation/attestation.go
@@ -46,7 +46,7 @@ func validateCommonAttestation(attestationCOSEBase64 enclaveapi.AttestationCOSEB
 		}
 	}
 
-	// Validate certificate chain
+	// Validate certificate chain at the attestation timestamp
 	if attestationDoc.Certificate == "" {
 		result.CertificateValid = false
 		result.ValidationDetails = append(result.ValidationDetails, "Missing certificate")
@@ -54,7 +54,7 @@ func validateCommonAttestation(attestationCOSEBase64 enclaveapi.AttestationCOSEB
 		result.CertificateValid = false
 		result.ValidationDetails = append(result.ValidationDetails, "Missing CA bundle")
 	} else {
-		err = ValidateCertificateChain(attestationDoc.Certificate, attestationDoc.CABundle)
+		err = ValidateCertificateChain(attestationDoc.Certificate, attestationDoc.CABundle, attestationDoc.Timestamp)
 		if err != nil {
 			result.CertificateValid = false
 			result.ValidationDetails = append(result.ValidationDetails, fmt.Sprintf("Certificate chain validation failed: %v", err))

--- a/validation/auctionvalidation.go
+++ b/validation/auctionvalidation.go
@@ -1,0 +1,222 @@
+package validation
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/cloudx-io/openauction/core"
+	enclaveapi "github.com/cloudx-io/openauction/enclaveapi"
+)
+
+// AuctionValidationInput contains all inputs needed for auction attestation validation
+type AuctionValidationInput struct {
+	AttestationCOSEGzip enclaveapi.AttestationCOSEGzip // Gzipped format from win/loss notifications
+	BidID               string
+	BidPrice            float64            // For unencrypted bids
+	EncryptedPayload    string             // For encrypted bids (base64-encoded encrypted data)
+	BidFloor            float64            // Always validated against attestation.bid_floor
+	ClearingPrice       *float64           // nil = no winner expected, non-nil = winner with this price
+	AdjustmentFactors   map[string]float64 // Compute hash and validate (empty map = no adjustments)
+	IsWinner            bool               // Expected auction result (true = expect to win, false = expect to lose)
+}
+
+// ValidateAuctionAttestation validates a TEE auction attestation and verifies:
+// - Bid was included in the auction
+// - Clearing price matches
+// - Bid floor matches
+// - Adjustment factors hash matches
+// - Winner/loser determination
+//
+// Returns:
+//   - AuctionValidationResult with detailed results (call result.IsValid() to check overall status)
+//   - error if validation cannot be performed (e.g., malformed input, missing config)
+func ValidateAuctionAttestation(input *AuctionValidationInput) (*AuctionValidationResult, error) {
+	// Decompress and convert attestation
+	attestationCOSE, err := input.AttestationCOSEGzip.Decompress()
+	if err != nil {
+		return nil, fmt.Errorf("decompress attestation: %w", err)
+	}
+	attestationCOSEBase64 := attestationCOSE.EncodeBase64()
+
+	// Perform common attestation validation (PCRs, certificate, signature)
+	baseResult, err := validateCommonAttestation(attestationCOSEBase64)
+	if err != nil {
+		return nil, err
+	}
+
+	// Parse auction attestation to get user data for auction-specific validation
+	auctionAttestation, err := parseAuctionAttestationFromCOSE(attestationCOSEBase64)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse attestation from attestation_cose_base64: %w", err)
+	}
+
+	// Create auction-specific result with base validation results
+	result := &AuctionValidationResult{
+		BaseValidationResult: *baseResult,
+	}
+
+	// Validate user data is present
+	if auctionAttestation.UserData == nil {
+		result.BidHashValid = false
+		result.ClearingPriceValid = false
+		result.BidFloorValid = false
+		result.AdjustmentHashValid = false
+		result.WinnerValid = false
+		result.ValidationDetails = append(result.ValidationDetails, "Attestation user data missing")
+		return result, nil
+	}
+
+	// Validate bid hash
+	result.BidHashValid = validateBidHash(input, auctionAttestation, result)
+
+	// Validate clearing price
+	result.ClearingPriceValid = validateClearingPrice(input, auctionAttestation, result)
+
+	// Validate bid floor
+	result.BidFloorValid = validateBidFloor(input, auctionAttestation, result)
+
+	// Validate adjustment factors hash
+	result.AdjustmentHashValid = validateAdjustmentHash(input, auctionAttestation, result)
+
+	// Validate winner determination
+	result.WinnerValid = validateWinnerAndRunnerUp(input, auctionAttestation, result)
+
+	return result, nil
+}
+
+func validateBidHash(input *AuctionValidationInput, attestation *enclaveapi.AuctionAttestationDoc, result *AuctionValidationResult) bool {
+	bidHashNonce := attestation.UserData.BidHashNonce
+	if bidHashNonce == "" {
+		result.ValidationDetails = append(result.ValidationDetails, "Bid hash nonce missing from attestation")
+		return false
+	}
+
+	// Compute hash based on whether bid was encrypted or not
+	var computedHash string
+	if input.EncryptedPayload != "" {
+		// Encrypted bid - hash the encrypted payload
+		computedHash = core.ComputeBidHashEncrypted(input.BidID, input.EncryptedPayload, bidHashNonce)
+		result.ValidationDetails = append(result.ValidationDetails, "Computing hash for encrypted bid")
+	} else {
+		// Unencrypted bid - hash the price
+		computedHash = core.ComputeBidHash(input.BidID, input.BidPrice, bidHashNonce)
+		result.ValidationDetails = append(result.ValidationDetails, "Computing hash for unencrypted bid")
+	}
+
+	for _, attestedHash := range attestation.UserData.BidHashes {
+		if computedHash == attestedHash {
+			result.ValidationDetails = append(result.ValidationDetails, fmt.Sprintf("Bid hash found in attestation: %s", computedHash))
+			return true
+		}
+	}
+
+	result.ValidationDetails = append(result.ValidationDetails, fmt.Sprintf("Bid hash NOT found in attestation. Computed: %s", computedHash))
+	result.ValidationDetails = append(result.ValidationDetails, fmt.Sprintf("Total hashes in attestation: %d", len(attestation.UserData.BidHashes)))
+	return false
+}
+
+func validateClearingPrice(input *AuctionValidationInput, attestation *enclaveapi.AuctionAttestationDoc, result *AuctionValidationResult) bool {
+	if input.ClearingPrice == nil {
+		// User expects no winner
+		if attestation.UserData.Winner == nil {
+			result.ValidationDetails = append(result.ValidationDetails, "Clearing price validation passed: no winner expected and no winner in attestation")
+			return true
+		}
+		result.ValidationDetails = append(result.ValidationDetails, fmt.Sprintf("Clearing price mismatch: expected no winner, but attestation has winner with price %.6f", attestation.UserData.Winner.Price))
+		return false
+	}
+
+	// User expects a winner with specific price
+	if attestation.UserData.Winner == nil {
+		result.ValidationDetails = append(result.ValidationDetails, fmt.Sprintf("Clearing price mismatch: expected winner with price %.6f, but attestation has no winner", *input.ClearingPrice))
+		return false
+	}
+
+	if *input.ClearingPrice == attestation.UserData.Winner.Price {
+		result.ValidationDetails = append(result.ValidationDetails, fmt.Sprintf("Clearing price validation passed: %.6f", *input.ClearingPrice))
+		return true
+	}
+
+	result.ValidationDetails = append(result.ValidationDetails, fmt.Sprintf("Clearing price mismatch: expected %.6f, attestation has %.6f", *input.ClearingPrice, attestation.UserData.Winner.Price))
+	return false
+}
+
+func validateBidFloor(input *AuctionValidationInput, attestation *enclaveapi.AuctionAttestationDoc, result *AuctionValidationResult) bool {
+	if input.BidFloor == attestation.UserData.BidFloor {
+		result.ValidationDetails = append(result.ValidationDetails, fmt.Sprintf("Bid floor validation passed: %.6f", input.BidFloor))
+		return true
+	}
+
+	result.ValidationDetails = append(result.ValidationDetails, fmt.Sprintf("Bid floor mismatch: expected %.6f, attestation has %.6f", input.BidFloor, attestation.UserData.BidFloor))
+	return false
+}
+
+func validateAdjustmentHash(input *AuctionValidationInput, attestation *enclaveapi.AuctionAttestationDoc, result *AuctionValidationResult) bool {
+	nonce := attestation.UserData.AdjustmentFactorsNonce
+	if nonce == "" {
+		result.ValidationDetails = append(result.ValidationDetails, "Adjustment factors nonce missing from attestation")
+		return false
+	}
+
+	computedHash := core.ComputeAdjustmentFactorsHash(input.AdjustmentFactors, nonce)
+	attestedHash := attestation.UserData.AdjustmentFactorsHash
+
+	if computedHash == attestedHash {
+		result.ValidationDetails = append(result.ValidationDetails, fmt.Sprintf("Adjustment factors hash validation passed: %s", computedHash))
+		return true
+	}
+
+	result.ValidationDetails = append(result.ValidationDetails, fmt.Sprintf("Adjustment factors hash mismatch: computed %s, attestation has %s", computedHash, attestedHash))
+	return false
+}
+
+func validateWinnerAndRunnerUp(input *AuctionValidationInput, attestation *enclaveapi.AuctionAttestationDoc, result *AuctionValidationResult) bool {
+	winner := attestation.UserData.Winner
+	actuallyWon := winner != nil && winner.ID == input.BidID
+
+	// Validate bidder's expectation matches attestation
+	if input.IsWinner == actuallyWon {
+		if actuallyWon {
+			result.ValidationDetails = append(result.ValidationDetails, fmt.Sprintf("Winner validation passed: bid won as expected (price: %.6f)", winner.Price))
+		} else {
+			result.ValidationDetails = append(result.ValidationDetails, "Winner validation passed: bid lost as expected")
+		}
+		return true
+	}
+
+	// Mismatch between expectation and reality
+	if input.IsWinner && !actuallyWon {
+		result.ValidationDetails = append(result.ValidationDetails, "Winner validation failed: expected to win, but did not win")
+	} else {
+		result.ValidationDetails = append(result.ValidationDetails, fmt.Sprintf("Winner validation failed: expected to lose, but won with price %.6f", winner.Price))
+	}
+	return false
+}
+
+// parseAuctionAttestationFromCOSE parses an AuctionAttestationDoc from base64-encoded COSE bytes
+// This extracts the attestation document from the COSE_Sign1 payload
+func parseAuctionAttestationFromCOSE(attestationCOSEB64 enclaveapi.AttestationCOSEBase64) (*enclaveapi.AuctionAttestationDoc, error) {
+	// Decode base64 COSE bytes
+	coseBytes, err := attestationCOSEB64.Decode()
+	if err != nil {
+		return nil, fmt.Errorf("decode COSE bytes: %w", err)
+	}
+
+	// Parse the CBOR attestation document using the standard method
+	// ParseAttestationDoc internally extracts the COSE_Sign1 payload and parses it
+	attestationDoc, userDataBytes, err := coseBytes.ParseAttestationDoc()
+	if err != nil {
+		return nil, err
+	}
+
+	// Parse user data as AuctionAttestationUserData
+	var userData enclaveapi.AuctionAttestationUserData
+	if err := json.Unmarshal(userDataBytes, &userData); err != nil {
+		return nil, fmt.Errorf("parse user data: %w", err)
+	}
+
+	return &enclaveapi.AuctionAttestationDoc{
+		AttestationDoc: attestationDoc,
+		UserData:       &userData,
+	}, nil
+}

--- a/validation/cmd/auction-validator/main.go
+++ b/validation/cmd/auction-validator/main.go
@@ -1,0 +1,325 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+
+	enclaveapi "github.com/cloudx-io/openauction/enclaveapi"
+	"github.com/cloudx-io/openauction/validation"
+)
+
+func main() {
+	// Define CLI flags
+	var (
+		bidRequestInput   = flag.String("bid-request", "", "Bid request JSON (file path or inline JSON)")
+		bidResponseInput  = flag.String("bid-response", "", "Bid response JSON (file path or inline JSON)")
+		notificationInput = flag.String("notification", "", "Win/loss notification params JSON (file path or inline JSON)")
+		outputFormat      = flag.String("format", "text", "Output format: text or json")
+		help              = flag.Bool("help", false, "Show usage information")
+	)
+
+	flag.Parse()
+
+	// Show help
+	if *help {
+		showUsage()
+		os.Exit(0)
+	}
+
+	// Check for required inputs
+	if *bidRequestInput == "" || *bidResponseInput == "" || *notificationInput == "" {
+		showUsage()
+		fmt.Fprintf(os.Stderr, "\nError: All three inputs are required (--bid-request, --bid-response, --notification)\n")
+		os.Exit(1)
+	}
+
+	// Parse inputs
+	bidRequest, err := readJSONInput(*bidRequestInput)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error reading bid request: %v\n", err)
+		os.Exit(2)
+	}
+
+	bidResponse, err := readJSONInput(*bidResponseInput)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error reading bid response: %v\n", err)
+		os.Exit(2)
+	}
+
+	notification, err := readJSONInput(*notificationInput)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error reading notification: %v\n", err)
+		os.Exit(2)
+	}
+
+	// Extract validation data
+	validationInput, err := extractValidationInput(bidRequest, bidResponse, notification)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error extracting validation data: %v\n", err)
+		os.Exit(2)
+	}
+
+	// Validate using library
+	result, err := validation.ValidateAuctionAttestation(validationInput)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Validation error: %v\n", err)
+		os.Exit(2)
+	}
+
+	// Output results
+	if *outputFormat == "json" {
+		outputJSON(result)
+	} else {
+		outputText(result)
+	}
+
+	// Exit with appropriate code
+	if !result.IsValid() {
+		os.Exit(1)
+	}
+	os.Exit(0)
+}
+
+func showUsage() {
+	fmt.Println("TEE Auction Attestation Validator")
+	fmt.Println()
+	fmt.Println("Validates TEE auction attestations using real bid request/response data.")
+	fmt.Println()
+	fmt.Println("Usage:")
+	fmt.Println("  auction-validator --bid-request <json> --bid-response <json> --notification <json> [options]")
+	fmt.Println()
+	fmt.Println("Required Flags:")
+	fmt.Println("  --bid-request <json>              OpenRTB bid request (what bidder received)")
+	fmt.Println("  --bid-response <json>             OpenRTB bid response (what bidder sent)")
+	fmt.Println("  --notification <json>             Win/loss notification params")
+	fmt.Println()
+	fmt.Println("Optional Flags:")
+	fmt.Println("  --format <text|json>              Output format (default: text)")
+	fmt.Println("  --help                            Show this help message")
+	fmt.Println()
+	fmt.Println("Input Format:")
+	fmt.Println("  Each flag accepts either a file path or inline JSON string.")
+	fmt.Println()
+	fmt.Println("Bid Request (from S3: {bidder}_request_0.json):")
+	fmt.Println("  {")
+	fmt.Println("    \"id\": \"auction-123\",")
+	fmt.Println("    \"imp\": [{\"bidfloor\": 2.00}],")
+	fmt.Println("    \"ext\": {")
+	fmt.Println("      \"prebid\": {")
+	fmt.Println("        \"bidadjustmentfactors\": {\"meta\": 1.0}")
+	fmt.Println("      }")
+	fmt.Println("    }")
+	fmt.Println("  }")
+	fmt.Println()
+	fmt.Println("Bid Response (from S3: {bidder}_response_0.json):")
+	fmt.Println("  {")
+	fmt.Println("    \"seatbid\": [{")
+	fmt.Println("      \"bid\": [{")
+	fmt.Println("        \"id\": \"bid-123\",")
+	fmt.Println("        \"price\": 2.50")
+	fmt.Println("      }]")
+	fmt.Println("    }]")
+	fmt.Println("  }")
+	fmt.Println()
+	fmt.Println("Notification (from win/loss URL params):")
+	fmt.Println("  {")
+	fmt.Println("    \"clearing_price\": 2.50,                          // or null if no winner")
+	fmt.Println("    \"is_winner\": true,                               // true for win, false for loss")
+	fmt.Println("    \"attestation_cose_gzip_base64\": \"H4sIAAAA...\"")
+	fmt.Println("  }")
+	fmt.Println()
+	fmt.Println("Examples:")
+	fmt.Println("  # Using files from S3 logs")
+	fmt.Println("  auction-validator \\")
+	fmt.Println("    --bid-request s3_logs/meta_request_0.json \\")
+	fmt.Println("    --bid-response s3_logs/meta_response_0.json \\")
+	fmt.Println("    --notification notification.json")
+	fmt.Println()
+	fmt.Println("  # Using inline JSON (winning bid)")
+	fmt.Println("  auction-validator \\")
+	fmt.Println("    --bid-request '{\"id\":\"auction-123\",\"imp\":[{\"bidfloor\":2.0}]}' \\")
+	fmt.Println("    --bid-response '{\"seatbid\":[{\"bid\":[{\"id\":\"bid-123\",\"price\":2.5}]}]}' \\")
+	fmt.Println("    --notification '{\"clearing_price\":2.5,\"is_winner\":true,\"attestation_cose_gzip_base64\":\"...\"}'")
+	fmt.Println()
+	fmt.Println("Exit Codes:")
+	fmt.Println("  0 - Validation passed")
+	fmt.Println("  1 - Validation failed")
+	fmt.Println("  2 - Invalid input or runtime error")
+}
+
+func readJSONInput(input string) ([]byte, error) {
+	// Try reading as file first
+	if data, err := os.ReadFile(input); err == nil {
+		return data, nil
+	}
+	// Treat as inline JSON
+	return []byte(input), nil
+}
+
+func extractValidationInput(bidRequestJSON, bidResponseJSON, notificationJSON []byte) (*validation.AuctionValidationInput, error) {
+	// Parse bid request
+	var bidRequest map[string]interface{}
+	if err := json.Unmarshal(bidRequestJSON, &bidRequest); err != nil {
+		return nil, fmt.Errorf("parse bid request: %w", err)
+	}
+
+	// Parse bid response
+	var bidResponse map[string]interface{}
+	if err := json.Unmarshal(bidResponseJSON, &bidResponse); err != nil {
+		return nil, fmt.Errorf("parse bid response: %w", err)
+	}
+
+	// Parse notification
+	var notification map[string]interface{}
+	if err := json.Unmarshal(notificationJSON, &notification); err != nil {
+		return nil, fmt.Errorf("parse notification: %w", err)
+	}
+
+	// Extract bid floor from first impression
+	bidFloor := 0.0
+	if imps, ok := bidRequest["imp"].([]interface{}); ok && len(imps) > 0 {
+		if imp, ok := imps[0].(map[string]interface{}); ok {
+			if floor, ok := imp["bidfloor"].(float64); ok {
+				bidFloor = floor
+			}
+		}
+	}
+
+	// Extract adjustment factors from ext.prebid.bidadjustmentfactors
+	adjustmentFactors := map[string]float64{}
+	if ext, ok := bidRequest["ext"].(map[string]interface{}); ok {
+		if prebid, ok := ext["prebid"].(map[string]interface{}); ok {
+			if factors, ok := prebid["bidadjustmentfactors"].(map[string]interface{}); ok {
+				for bidder, factor := range factors {
+					if f, ok := factor.(float64); ok {
+						adjustmentFactors[bidder] = f
+					}
+				}
+			}
+		}
+	}
+
+	// Extract bid_id, bid_price, and optional encrypted_payload from bid response
+	var bidID string
+	var bidPrice float64
+	var encryptedPayload string
+
+	if seatbids, ok := bidResponse["seatbid"].([]interface{}); ok && len(seatbids) > 0 {
+		if seatbid, ok := seatbids[0].(map[string]interface{}); ok {
+			if bids, ok := seatbid["bid"].([]interface{}); ok && len(bids) > 0 {
+				if bid, ok := bids[0].(map[string]interface{}); ok {
+					if id, ok := bid["id"].(string); ok {
+						bidID = id
+					}
+					if price, ok := bid["price"].(float64); ok {
+						bidPrice = price
+					}
+
+					// Check for encrypted bid
+					if ext, ok := bid["ext"].(map[string]interface{}); ok {
+						if encBid, ok := ext["encrypted_bid"].(map[string]interface{}); ok {
+							if payload, ok := encBid["encrypted_payload"].(string); ok {
+								encryptedPayload = payload
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+
+	if bidID == "" {
+		return nil, fmt.Errorf("missing or invalid bid ID in bid response")
+	}
+
+	// Extract clearing_price from notification (can be null)
+	var clearingPrice *float64
+	if cp, ok := notification["clearing_price"]; ok && cp != nil {
+		if cpFloat, ok := cp.(float64); ok {
+			clearingPrice = &cpFloat
+		}
+	}
+
+	// Extract attestation from notification
+	attestationStr, ok := notification["attestation_cose_gzip_base64"].(string)
+	if !ok || attestationStr == "" {
+		return nil, fmt.Errorf("missing or invalid 'attestation_cose_gzip_base64' in notification")
+	}
+
+	// Extract isWinner from notification (defaults to false if not present)
+	isWinner := false
+	if winner, ok := notification["is_winner"].(bool); ok {
+		isWinner = winner
+	}
+
+	return &validation.AuctionValidationInput{
+		AttestationCOSEGzip: enclaveapi.AttestationCOSEGzip(attestationStr),
+		BidID:               bidID,
+		BidPrice:            bidPrice,
+		EncryptedPayload:    encryptedPayload,
+		BidFloor:            bidFloor,
+		ClearingPrice:       clearingPrice,
+		AdjustmentFactors:   adjustmentFactors,
+		IsWinner:            isWinner,
+	}, nil
+}
+
+func outputText(result *validation.AuctionValidationResult) {
+	fmt.Println("TEE Auction Attestation Validator")
+	fmt.Println("==================================")
+	fmt.Println()
+
+	fmt.Println("Validation Results:")
+	fmt.Println("-------------------")
+
+	fmt.Println()
+	fmt.Println("Summary:")
+	fmt.Printf("  PCRs Valid:              %v\n", result.PCRsValid)
+	fmt.Printf("  Certificate Valid:       %v\n", result.CertificateValid)
+	fmt.Printf("  Signature Valid:         %v\n", result.SignatureValid)
+	fmt.Printf("  Bid Hash Valid:          %v\n", result.BidHashValid)
+	fmt.Printf("  Clearing Price Valid:    %v\n", result.ClearingPriceValid)
+	fmt.Printf("  Bid Floor Valid:         %v\n", result.BidFloorValid)
+	fmt.Printf("  Adjustment Hash Valid:   %v\n", result.AdjustmentHashValid)
+	fmt.Printf("  Winner Valid:            %v\n", result.WinnerValid)
+
+	fmt.Println()
+	fmt.Println("Details:")
+	for _, detail := range result.ValidationDetails {
+		fmt.Printf("  - %s\n", detail)
+	}
+
+	fmt.Println()
+	fmt.Println("==================================")
+	if result.IsValid() {
+		fmt.Println("VALIDATION: ✓ PASSED")
+		fmt.Println("Exit Code: 0")
+	} else {
+		fmt.Println("VALIDATION: ✗ FAILED")
+		fmt.Println("Exit Code: 1")
+	}
+}
+
+func outputJSON(result *validation.AuctionValidationResult) {
+	output := map[string]any{
+		"valid":                 result.IsValid(),
+		"pcrs_valid":            result.PCRsValid,
+		"certificate_valid":     result.CertificateValid,
+		"signature_valid":       result.SignatureValid,
+		"bid_hash_valid":        result.BidHashValid,
+		"clearing_price_valid":  result.ClearingPriceValid,
+		"bid_floor_valid":       result.BidFloorValid,
+		"adjustment_hash_valid": result.AdjustmentHashValid,
+		"winner_valid":          result.WinnerValid,
+		"details":               result.ValidationDetails,
+	}
+
+	data, err := json.MarshalIndent(output, "", "  ")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error marshaling JSON: %v\n", err)
+		os.Exit(2)
+	}
+	fmt.Println(string(data))
+}

--- a/validation/types.go
+++ b/validation/types.go
@@ -8,6 +8,11 @@ type BaseValidationResult struct {
 	ValidationDetails []string
 }
 
+// IsValid returns true if all base validation checks passed
+func (r *BaseValidationResult) IsValid() bool {
+	return r.PCRsValid && r.CertificateValid && r.SignatureValid
+}
+
 // KeyValidationResult contains validation results specific to key attestations
 type KeyValidationResult struct {
 	BaseValidationResult
@@ -16,7 +21,27 @@ type KeyValidationResult struct {
 
 // IsValid returns true if all key validation checks passed
 func (r *KeyValidationResult) IsValid() bool {
-	return r.PCRsValid && r.CertificateValid && r.SignatureValid && r.PublicKeyMatch
+	return r.BaseValidationResult.IsValid() && r.PublicKeyMatch
+}
+
+// AuctionValidationResult contains validation results specific to auction attestations
+type AuctionValidationResult struct {
+	BaseValidationResult
+	BidHashValid        bool
+	ClearingPriceValid  bool
+	BidFloorValid       bool
+	AdjustmentHashValid bool
+	WinnerValid         bool
+}
+
+// IsValid returns true if all auction validation checks passed
+func (r *AuctionValidationResult) IsValid() bool {
+	return r.BaseValidationResult.IsValid() &&
+		r.BidHashValid &&
+		r.ClearingPriceValid &&
+		r.BidFloorValid &&
+		r.AdjustmentHashValid &&
+		r.WinnerValid
 }
 
 // PCRSet represents a known-good set of PCR measurements


### PR DESCRIPTION
## Summary

Adds CLI tool for validating TEE auction attestations from the bidder's perspective.

## Usage

```bash
auction-validator \
  --bid-request <received_from_ssp.json> \
  --bid-response <sent_to_ssp.json> \
  --notification <win_or_loss_params.json>
```

## Breaking changes

Introduces a separate hashing function for encrypted bids. This is necessary for external validation of bid hashes, since the validation script cannot decrypt bids.

## Validations

- Code integrity via PCR measurements
- Certificate chain at attestation time
- Bid inclusion (encrypted and unencrypted)
- Clearing price integrity
- Bid floor enforcement
- Bid adjustment integrity
- Winner/loser determination

## TODO

I want to make sure I've nailed the logic for bid hash inclusion. In particular, handling edge cases like encrypted bids that fail to decrypt in the TEE. There may be some changes there. Also, I might consolidate the two separate hash functions (encrypted / unencrypted bids) into a single function for simplicity.

## Testing

All tests pass. Validated with real auction data.