### PR TITLE
fix issues in EIF workflow

### DIFF
--- a/.github/workflows/eif-build.yml
+++ b/.github/workflows/eif-build.yml
@@ -338,28 +338,23 @@ jobs:
         if: always()
         run: |
           if [ -n "${{ steps.launch-instance.outputs.instance_id }}" ]; then
+            echo "Terminating instance..."
             aws ec2 terminate-instances \
               --instance-ids "${{ steps.launch-instance.outputs.instance_id }}"
+
+            echo "Waiting for instance to terminate..."
+            aws ec2 wait instance-terminated \
+              --instance-ids "${{ steps.launch-instance.outputs.instance_id }}" \
+              --cli-read-timeout 300
           fi
       
       - name: Cleanup security group
         if: always()
         run: |
           if [ -n "${{ steps.security-group.outputs.security_group_id }}" ]; then
-            # Wait for instance to fully terminate before deleting security group
-            if [ -n "${{ steps.launch-instance.outputs.instance_id }}" ]; then
-              echo "Waiting for instance to terminate..."
-              aws ec2 wait instance-terminated \
-                --instance-ids "${{ steps.launch-instance.outputs.instance_id }}" \
-                --cli-read-timeout 300 || true
-            fi
-
             echo "Deleting security group..."
             aws ec2 delete-security-group \
-              --group-id "${{ steps.security-group.outputs.security_group_id }}" || {
-              echo "Warning: Could not delete security group (may still be attached)"
-              echo "It will be automatically cleaned up after instance fully terminates"
-            }
+              --group-id "${{ steps.security-group.outputs.security_group_id }}"
           fi
       
       - name: Cleanup key pair

--- a/.github/workflows/eif-build.yml
+++ b/.github/workflows/eif-build.yml
@@ -41,7 +41,7 @@ on:
 
 env:
   AWS_REGION: us-east-1
-  INSTANCE_TYPE: m5.xlarge
+  INSTANCE_TYPE: c5.xlarge
   # Amazon Linux 2023 AMI
   # Update periodically to latest AMI
   #

--- a/.github/workflows/eif-build.yml
+++ b/.github/workflows/eif-build.yml
@@ -188,7 +188,7 @@ jobs:
           
           echo "Waiting for instance to be running..."
           aws ec2 wait instance-running --instance-ids "${INSTANCE_ID}"
-          
+
           echo "Waiting for status checks..."
           aws ec2 wait instance-status-ok --instance-ids "${INSTANCE_ID}"
           
@@ -346,9 +346,20 @@ jobs:
         if: always()
         run: |
           if [ -n "${{ steps.security-group.outputs.security_group_id }}" ]; then
-            sleep 10
+            # Wait for instance to fully terminate before deleting security group
+            if [ -n "${{ steps.launch-instance.outputs.instance_id }}" ]; then
+              echo "Waiting for instance to terminate..."
+              aws ec2 wait instance-terminated \
+                --instance-ids "${{ steps.launch-instance.outputs.instance_id }}" \
+                --cli-read-timeout 300 || true
+            fi
+
+            echo "Deleting security group..."
             aws ec2 delete-security-group \
-              --group-id "${{ steps.security-group.outputs.security_group_id }}" || true
+              --group-id "${{ steps.security-group.outputs.security_group_id }}" || {
+              echo "Warning: Could not delete security group (may still be attached)"
+              echo "It will be automatically cleaned up after instance fully terminates"
+            }
           fi
       
       - name: Cleanup key pair

--- a/.github/workflows/eif-build.yml
+++ b/.github/workflows/eif-build.yml
@@ -41,7 +41,7 @@ on:
 
 env:
   AWS_REGION: us-east-1
-  INSTANCE_TYPE: c5.xlarge
+  INSTANCE_TYPE: m5.xlarge
   # Amazon Linux 2023 AMI
   # Update periodically to latest AMI
   #
@@ -132,14 +132,16 @@ jobs:
             --query 'Vpcs[0].VpcId' \
             --output text)
           
+          # Use us-east-1a for consistent instance type availability
           SUBNET_ID=$(aws ec2 describe-subnets \
             --filters "Name=vpc-id,Values=${VPC_ID}" \
+                      "Name=availability-zone,Values=us-east-1a" \
             --query 'Subnets[0].SubnetId' \
             --output text)
           
           echo "vpc_id=${VPC_ID}" >> $GITHUB_OUTPUT
           echo "subnet_id=${SUBNET_ID}" >> $GITHUB_OUTPUT
-          echo "Using VPC: ${VPC_ID}, Subnet: ${SUBNET_ID}"
+          echo "Using VPC: ${VPC_ID}, Subnet: ${SUBNET_ID} (us-east-1a)"
       
       - name: Create security group
         id: security-group

--- a/enclave/scripts/build-eif-ci.sh
+++ b/enclave/scripts/build-eif-ci.sh
@@ -149,34 +149,41 @@ main() {
     
     local measurements_file="${EIF_FILE}.measurements.json"
     
+    # Save raw output first for debugging
+    cp "$build_output" "$measurements_file"
+
     # Parse the nitro-cli output and extract measurements
     if command -v jq > /dev/null 2>&1 && [ -f "$build_output" ]; then
-        # Pretty-print to measurements file
-        cat "$build_output" | jq '.' > "$measurements_file" 2>/dev/null || {
-            log_error "Failed to parse PCR measurements with jq"
-            cat "$build_output" > "$measurements_file"
-        }
-        
-        # Extract key measurements
+        # Try to parse as JSON and extract PCRs
         local pcr0 pcr1 pcr2
-        pcr0=$(cat "$build_output" | jq -r '.Measurements.PCR0 // "unknown"' 2>/dev/null || echo "unknown")
-        pcr1=$(cat "$build_output" | jq -r '.Measurements.PCR1 // "unknown"' 2>/dev/null || echo "unknown")
-        pcr2=$(cat "$build_output" | jq -r '.Measurements.PCR2 // "unknown"' 2>/dev/null || echo "unknown")
         
+        # nitro-cli outputs JSON with PCRs in base64-encoded format
+        # Try different possible JSON structures
+        if jq -e '.Measurements' "$build_output" > /dev/null 2>&1; then
+            pcr0=$(jq -r '.Measurements.PCR0 // "unknown"' "$build_output" 2>/dev/null || echo "unknown")
+            pcr1=$(jq -r '.Measurements.PCR1 // "unknown"' "$build_output" 2>/dev/null || echo "unknown")
+            pcr2=$(jq -r '.Measurements.PCR2 // "unknown"' "$build_output" 2>/dev/null || echo "unknown")
+        else
+            # Alternative: extract from text output if not valid JSON
+            log "Output is not JSON, attempting text parsing..."
+            pcr0=$(grep -i "PCR0" "$build_output" | awk '{print $NF}' || echo "unknown")
+            pcr1=$(grep -i "PCR1" "$build_output" | awk '{print $NF}' || echo "unknown")
+            pcr2=$(grep -i "PCR2" "$build_output" | awk '{print $NF}' || echo "unknown")
+        fi
+
         log "PCR Measurements:"
         log "  PCR0: $pcr0"
         log "  PCR1: $pcr1"
         log "  PCR2: $pcr2"
         
-        # Output for GitHub Actions (can be captured)
+        # Output for GitHub Actions
         echo "PCR0=$pcr0"
         echo "PCR1=$pcr1"
         echo "PCR2=$pcr2"
         
     else
-        log "jq not available, saving raw output"
-        cat "$build_output" > "$measurements_file"
-        log "Raw PCR measurements saved to: $measurements_file"
+        log "jq not available, raw output saved"
+        log "PCR measurements file: $measurements_file"
     fi
 
     log "✓ PCR measurements saved to: $measurements_file"

--- a/enclave/scripts/build-eif-ci.sh
+++ b/enclave/scripts/build-eif-ci.sh
@@ -166,9 +166,20 @@ main() {
         else
             # Alternative: extract from text output if not valid JSON
             log "Output is not JSON, attempting text parsing..."
-            pcr0=$(grep -i "PCR0" "$build_output" | awk '{print $NF}' || echo "unknown")
-            pcr1=$(grep -i "PCR1" "$build_output" | awk '{print $NF}' || echo "unknown")
-            pcr2=$(grep -i "PCR2" "$build_output" | awk '{print $NF}' || echo "unknown")
+            pcr0=$(grep -i "PCR0" "$build_output" | awk '{print $NF}' | tr -d ',"' || echo "unknown")
+            pcr1=$(grep -i "PCR1" "$build_output" | awk '{print $NF}' | tr -d ',"' || echo "unknown")
+            pcr2=$(grep -i "PCR2" "$build_output" | awk '{print $NF}' | tr -d ',"' || echo "unknown")
+
+            # Create a proper JSON file for GitHub Actions
+            cat > "$measurements_file" <<EOF
+{
+  "Measurements": {
+    "PCR0": "$pcr0",
+    "PCR1": "$pcr1",
+    "PCR2": "$pcr2"
+  }
+}
+EOF
         fi
 
         log "PCR Measurements:"


### PR DESCRIPTION
## Summary

Fixes issues in EIF workflow.

## Changes

- Use `us-east-1a` for reliable instance availability
- Start Docker daemon after installation (`nitro-cli` pulls it as dependency but doesn't start it)
- Parse PCR values from text output and generate clean JSON (`nitro-cli` outputs text, not JSON)
- Wait for instance termination before deleting security group (prevents orphaned resources)

## Testing

Workflow now completes successfully. PCR values extracted and EIF pushed to ECR.

Identical docker images build EIFs with identical PCRs:
- https://github.com/cloudx-io/openauction/actions/runs/20447509903
- https://github.com/cloudx-io/openauction/actions/runs/20447627467