### PR TITLE
Fix EIF image tag format to match Docker workflow

### DIFF
--- a/.github/workflows/eif-build.yml
+++ b/.github/workflows/eif-build.yml
@@ -132,14 +132,16 @@ jobs:
             --query 'Vpcs[0].VpcId' \
             --output text)
           
+          # Use us-east-1a for consistent instance type availability
           SUBNET_ID=$(aws ec2 describe-subnets \
             --filters "Name=vpc-id,Values=${VPC_ID}" \
+                      "Name=availability-zone,Values=us-east-1a" \
             --query 'Subnets[0].SubnetId' \
             --output text)
           
           echo "vpc_id=${VPC_ID}" >> $GITHUB_OUTPUT
           echo "subnet_id=${SUBNET_ID}" >> $GITHUB_OUTPUT
-          echo "Using VPC: ${VPC_ID}, Subnet: ${SUBNET_ID}"
+          echo "Using VPC: ${VPC_ID}, Subnet: ${SUBNET_ID} (us-east-1a)"
       
       - name: Create security group
         id: security-group
@@ -186,7 +188,7 @@ jobs:
           
           echo "Waiting for instance to be running..."
           aws ec2 wait instance-running --instance-ids "${INSTANCE_ID}"
-          
+
           echo "Waiting for status checks..."
           aws ec2 wait instance-status-ok --instance-ids "${INSTANCE_ID}"
           
@@ -336,17 +338,23 @@ jobs:
         if: always()
         run: |
           if [ -n "${{ steps.launch-instance.outputs.instance_id }}" ]; then
+            echo "Terminating instance..."
             aws ec2 terminate-instances \
               --instance-ids "${{ steps.launch-instance.outputs.instance_id }}"
+
+            echo "Waiting for instance to terminate..."
+            aws ec2 wait instance-terminated \
+              --instance-ids "${{ steps.launch-instance.outputs.instance_id }}" \
+              --cli-read-timeout 300
           fi
       
       - name: Cleanup security group
         if: always()
         run: |
           if [ -n "${{ steps.security-group.outputs.security_group_id }}" ]; then
-            sleep 10
+            echo "Deleting security group..."
             aws ec2 delete-security-group \
-              --group-id "${{ steps.security-group.outputs.security_group_id }}" || true
+              --group-id "${{ steps.security-group.outputs.security_group_id }}"
           fi
       
       - name: Cleanup key pair

--- a/.github/workflows/eif-build.yml
+++ b/.github/workflows/eif-build.yml
@@ -104,7 +104,7 @@ jobs:
             echo "Using manually specified image tag: ${IMAGE_TAG}"
           else
             COMMIT_SHA="${{ steps.set-sha.outputs.commit_sha }}"
-            IMAGE_TAG="sha-${COMMIT_SHA}"
+            IMAGE_TAG="${COMMIT_SHA}"
             echo "Using commit-based image tag: ${IMAGE_TAG}"
           fi
 
@@ -289,7 +289,7 @@ jobs:
           REGISTRY="${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${{ env.AWS_REGION }}.amazonaws.com"
           REPO="cloudx-io/openauction/enclave-eif"
           
-          oras push "${REGISTRY}/${REPO}:sha-${COMMIT_SHA}" \
+          oras push "${REGISTRY}/${REPO}:${COMMIT_SHA}" \
             --artifact-type application/vnd.aws.nitro.eif \
             --annotation "org.opencontainers.image.created=$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
             --annotation "org.opencontainers.image.revision=${COMMIT_SHA}" \
@@ -300,10 +300,10 @@ jobs:
             measurements.json:application/json
           
           if [ "${{ github.ref }}" = "refs/heads/main" ]; then
-            oras tag "${REGISTRY}/${REPO}:sha-${COMMIT_SHA}" latest
+            oras tag "${REGISTRY}/${REPO}:${COMMIT_SHA}" latest
           fi
           
-          oras tag "${REGISTRY}/${REPO}:sha-${COMMIT_SHA}" "sha-${COMMIT_SHORT}"
+          oras tag "${REGISTRY}/${REPO}:${COMMIT_SHA}" "${COMMIT_SHORT}"
       
       - name: Upload artifacts
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
Remove 'sha-' prefix from EIF image tags to match Docker workflow output. Docker workflow creates tags without prefix (e.g., 'a57b1b8'), so EIF workflow should reference them the same way.

This fixes the 'manifest not found' errors when EIF workflow tries to pull images with 'sha-' prefix that don't exist.