### PR TITLE
send gzipped key attestation instead of raw json

### DIFF
--- a/enclave/auction_test.go
+++ b/enclave/auction_test.go
@@ -629,13 +629,12 @@ func TestEndToEndTokenFlow(t *testing.T) {
 	keyManager, _ := NewKeyManager()
 	tokenManager := NewTokenManager()
 
-	// Request key and get token from attestation user_data
+	// Request key and auction token
 	keyResp, err := HandleKeyRequest(mockAttester, keyManager, tokenManager)
 	check.NoError(t, err)
 	check.NotEqual(t, "", keyResp.PublicKey)
-	check.NotNil(t, keyResp.KeyAttestation)
-	check.NotEqual(t, "", keyResp.KeyAttestation.UserData.AuctionToken)
-	token := keyResp.KeyAttestation.UserData.AuctionToken
+	check.NotEqual(t, "", keyResp.AuctionToken)
+	token := keyResp.AuctionToken
 
 	// Token should be valid
 	check.True(t, tokenManager.ValidateToken(token))

--- a/enclaveapi/types.go
+++ b/enclaveapi/types.go
@@ -158,17 +158,17 @@ type EnclaveAuctionResponse struct {
 
 // KeyResponse represents the response from a key request to the TEE enclave
 type KeyResponse struct {
+	KeyWithAttestation
 	Type                  string                `json:"type"`
-	PublicKey             string                `json:"public_key"`                        // PEM format
-	KeyAttestation        *KeyAttestationDoc    `json:"key_attestation"`                   // Deprecated: Use attestation_cose_base64 instead
-	AttestationCOSEBase64 AttestationCOSEBase64 `json:"attestation_cose_base64,omitempty"` // Base64-encoded COSE_Sign1 attestation
+	AttestationCOSEBase64 AttestationCOSEBase64 `json:"attestation_cose_base64,omitempty"` // Deprecated: for backward compatibility during migration
 }
 
 // KeyWithAttestation represents a public key with its TEE attestation
 // Used in bid requests and key validation tools
 type KeyWithAttestation struct {
-	PublicKey   string              `json:"public_key"`                             // PEM-encoded RSA public key
-	Attestation AttestationCOSEGzip `json:"attestation_cose_gzip_base64,omitempty"` // Gzipped and base64-encoded COSE_Sign1 attestation
+	PublicKey    string              `json:"public_key"`                   // PEM-encoded RSA public key
+	Attestation  AttestationCOSEGzip `json:"attestation_cose_gzip_base64"` // Gzipped and base64-encoded COSE_Sign1 attestation
+	AuctionToken string              `json:"auction_token"`                // Single-use token for bid replay protection
 }
 
 // KeyAttestationUserData represents the key-specific data embedded in key attestation


### PR DESCRIPTION
# Refactor KeyResponse to use pre-compressed attestations

## Summary
Refactors `KeyResponse` to use Go struct embedding, consolidating key attestation data into top-level fields. Attestations are now pre-compressed (gzipped) by the TEE, reducing payload size and simplifying SSP integration.

## Key Changes

### 1. Struct Embedding
```go
// Before
type KeyResponse struct {
    KeyAttestation *KeyAttestationDoc  // Nested structure
    ...
}

// After  
type KeyResponse struct {
    KeyWithAttestation  // Embedded - promotes fields to top level
    ...
}
```

**Result:** Direct field access (`keyResponse.AuctionToken`) instead of nested navigation (`keyResponse.KeyAttestation.UserData.AuctionToken`)

### 2. Pre-compressed Attestations
- TEE now gzips attestations before sending
- SSP won't need to compress in future update

### 3. Simplified API
```go
// Before: func GenerateKeyAttestation(...) (*KeyAttestationDoc, AttestationCOSE, error)
// After:  func GenerateKeyAttestation(...) (AttestationCOSE, error)
```

### 4. Added AuctionToken to KeyWithAttestation
```go
type KeyWithAttestation struct {
    PublicKey    string
    Attestation  AttestationCOSEGzip  // Gzipped!
    AuctionToken string               // NEW
}
```

## JSON Output
```json
{
  "public_key": "...",
  "attestation_cose_gzip_base64": "H4sIAAAA...",
  "auction_token": "550e8400-...",
  "type": "key_response",
  "attestation_cose_base64": "..."
}
```

All fields at top level. Attestation is gzipped. `attestation_cose_base64` kept for backward compatibility.

## Migration Path
1. **Phase 1 (this PR)**: TEE sends new format, keeps old fields
2. **Phase 2**: Update SSP to read new fields directly
3. **Phase 3**: Remove deprecated `attestation_cose_base64` field