### PR TITLE
add back KeyAttestation to KeyResponse for backwards compatibility

### DIFF
--- a/enclave/keymanager.go
+++ b/enclave/keymanager.go
@@ -65,6 +65,16 @@ func HandleKeyRequest(attester EnclaveAttester, keyManager *KeyManager, tokenMan
 		return nil, fmt.Errorf("failed to compress attestation: %w", err)
 	}
 
+	keyUserData := &enclaveapi.KeyAttestationUserData{
+		KeyAlgorithm: "RSA-2048",
+		PublicKey:    publicKeyPEM,
+		AuctionToken: auctionToken,
+	}
+	keyAttestation, err := ParseKeyAttestation(coseAttestation, keyUserData)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse key attestation: %w", err)
+	}
+
 	return &enclaveapi.KeyResponse{
 		KeyWithAttestation: enclaveapi.KeyWithAttestation{
 			PublicKey:    publicKeyPEM,
@@ -72,6 +82,7 @@ func HandleKeyRequest(attester EnclaveAttester, keyManager *KeyManager, tokenMan
 			AuctionToken: auctionToken,
 		},
 		Type:                  "key_response",
-		AttestationCOSEBase64: coseAttestation.EncodeBase64(), // Deprecated: kept for backward compatibility during migration
+		KeyAttestation:        keyAttestation,
+		AttestationCOSEBase64: coseAttestation.EncodeBase64(),
 	}, nil
 }

--- a/enclaveapi/types.go
+++ b/enclaveapi/types.go
@@ -160,6 +160,7 @@ type EnclaveAuctionResponse struct {
 type KeyResponse struct {
 	KeyWithAttestation
 	Type                  string                `json:"type"`
+	KeyAttestation        *KeyAttestationDoc    `json:"key_attestation,omitempty"`         // Deprecated: for backward compatibility, will be removed after SSP migration
 	AttestationCOSEBase64 AttestationCOSEBase64 `json:"attestation_cose_base64,omitempty"` // Deprecated: for backward compatibility during migration
 }
 


### PR DESCRIPTION
`KeyResponse` is still accessed by SSP. This will be removed after SSP is updated to read from `AuctionToken`.