### PR TITLE
remove deprecated fields from KeyResponse

### DIFF
--- a/enclave/keymanager.go
+++ b/enclave/keymanager.go
@@ -65,24 +65,12 @@ func HandleKeyRequest(attester EnclaveAttester, keyManager *KeyManager, tokenMan
 		return nil, fmt.Errorf("failed to compress attestation: %w", err)
 	}
 
-	keyUserData := &enclaveapi.KeyAttestationUserData{
-		KeyAlgorithm: "RSA-2048",
-		PublicKey:    publicKeyPEM,
-		AuctionToken: auctionToken,
-	}
-	keyAttestation, err := ParseKeyAttestation(coseAttestation, keyUserData)
-	if err != nil {
-		return nil, fmt.Errorf("failed to parse key attestation: %w", err)
-	}
-
 	return &enclaveapi.KeyResponse{
 		KeyWithAttestation: enclaveapi.KeyWithAttestation{
 			PublicKey:    publicKeyPEM,
 			Attestation:  attestationGzip,
 			AuctionToken: auctionToken,
 		},
-		Type:                  "key_response",
-		KeyAttestation:        keyAttestation,
-		AttestationCOSEBase64: coseAttestation.EncodeBase64(),
+		Type: "key_response",
 	}, nil
 }

--- a/enclave/proofs.go
+++ b/enclave/proofs.go
@@ -216,19 +216,3 @@ func GenerateKeyAttestation(attester EnclaveAttester, publicKey *rsa.PublicKey, 
 
 	return enclaveapi.AttestationCOSE(attestationCBOR), nil
 }
-
-// ParseKeyAttestation parses CBOR attestation specifically for key attestation
-// TODO: remove after KeyResponse.KeyAttestation is removed
-func ParseKeyAttestation(cborData []byte, keyUserData *enclaveapi.KeyAttestationUserData) (*enclaveapi.KeyAttestationDoc, error) {
-	attestationDoc, _, err := enclaveapi.AttestationCOSE(cborData).ParseAttestationDoc()
-	if err != nil {
-		return nil, fmt.Errorf("failed to parse attestation: %w", err)
-	}
-
-	log.Printf("INFO: Successfully parsed key attestation document with module ID: %s", attestationDoc.ModuleID)
-
-	return &enclaveapi.KeyAttestationDoc{
-		AttestationDoc: attestationDoc,
-		UserData:       keyUserData,
-	}, nil
-}

--- a/enclaveapi/types.go
+++ b/enclaveapi/types.go
@@ -159,9 +159,7 @@ type EnclaveAuctionResponse struct {
 // KeyResponse represents the response from a key request to the TEE enclave
 type KeyResponse struct {
 	KeyWithAttestation
-	Type                  string                `json:"type"`
-	KeyAttestation        *KeyAttestationDoc    `json:"key_attestation,omitempty"`         // Deprecated: for backward compatibility, will be removed after SSP migration
-	AttestationCOSEBase64 AttestationCOSEBase64 `json:"attestation_cose_base64,omitempty"` // Deprecated: for backward compatibility during migration
+	Type string `json:"type"`
 }
 
 // KeyWithAttestation represents a public key with its TEE attestation


### PR DESCRIPTION
# Remove deprecated fields from KeyResponse

## Summary
Removes deprecated `KeyAttestation` and `AttestationCOSEBase64` fields from `KeyResponse`.

## Changes

### 1. Simplified KeyResponse (`enclaveapi/types.go`)
```go
// Before
type KeyResponse struct {
    KeyWithAttestation
    Type                  string
    KeyAttestation        *KeyAttestationDoc    // Removed
    AttestationCOSEBase64 AttestationCOSEBase64 // Removed
}

// After
type KeyResponse struct {
    KeyWithAttestation
    Type string
}
```

### 2. Cleaned Up Key Manager
- Removed code to populate `KeyAttestation`
- Removed code to populate `AttestationCOSEBase64`

### 3. Removed Dead Code
- Removed `ParseKeyAttestation()` function

### 4. Updated Tests
- Parse COSE directly using `AttestationCOSE.ParseAttestationDoc()`
- No longer uses deprecated wrapper function

## JSON Output
```json
{
  "public_key": "...",
  "attestation_cose_gzip_base64": "...",
  "auction_token": "...",
  "type": "key_response"
}
```

Clean final state - only essential fields remain.