### PR TITLE
avoid extra EIF build workflow runs

### DIFF
--- a/.github/workflows/eif-build.yml
+++ b/.github/workflows/eif-build.yml
@@ -58,7 +58,7 @@ jobs:
   build-eif:
     name: Build EIF on Nitro EC2
     runs-on: ubuntu-latest
-    if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
+    if: github.event_name == 'workflow_dispatch' || (github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == 'main')
     permissions:
       id-token: write
       contents: read


### PR DESCRIPTION
## Summary

Fix EIF build workflow running on PRs instead of only on main branch commits.

## Problem

The `workflow_run` trigger's `branches: [main]` filter doesn't work reliably with chained workflows (Go → Docker Build → EIF Build), causing EIF generation to run on every PR.

## Solution

Add explicit branch check to job condition: `github.event.workflow_run.head_branch == 'main'`

## Impact

- EIF builds now only run on main branch commits (or manual triggers)