### PR TITLE
roundID type changed from int to string

### DIFF
--- a/core/hash.go
+++ b/core/hash.go
@@ -23,8 +23,8 @@ func ComputeBidHash(bidID string, price float64, nonce string) string {
 // This is used by both the enclave (to generate hashes) and validation (to verify hashes).
 //
 // Formula: SHA256(auction_id + "|" + round_id + "|" + nonce)
-func ComputeRequestHash(auctionID string, roundID int, nonce string) string {
-	data := fmt.Sprintf("%s|%d|%s", auctionID, roundID, nonce)
+func ComputeRequestHash(auctionID string, roundID string, nonce string) string {
+	data := fmt.Sprintf("%s|%s|%s", auctionID, roundID, nonce)
 	hash := sha256.Sum256([]byte(data))
 	return fmt.Sprintf("%x", hash)
 }

--- a/core/hash_test.go
+++ b/core/hash_test.go
@@ -135,7 +135,7 @@ func TestComputeBidHash_EdgeCases(t *testing.T) {
 
 func TestComputeRequestHash(t *testing.T) {
 	auctionID := "auction-123"
-	roundID := 1
+	roundID := "auction-123-1"
 	nonce := "test-nonce"
 
 	hash := ComputeRequestHash(auctionID, roundID, nonce)
@@ -159,7 +159,7 @@ func TestComputeRequestHash(t *testing.T) {
 	}
 
 	// Test that different inputs produce different hashes
-	hash3 := ComputeRequestHash(auctionID, roundID+1, nonce)
+	hash3 := ComputeRequestHash(auctionID, roundID+"1", nonce)
 	if hash == hash3 {
 		t.Errorf("Different round IDs should produce different hashes")
 	}
@@ -175,7 +175,7 @@ func TestComputeRequestHash(t *testing.T) {
 	}
 
 	// Verify exact hash calculation
-	expectedData := fmt.Sprintf("%s|%d|%s", auctionID, roundID, nonce)
+	expectedData := fmt.Sprintf("%s|%s|%s", auctionID, roundID, nonce)
 	expectedHash := fmt.Sprintf("%x", sha256.Sum256([]byte(expectedData)))
 	if hash != expectedHash {
 		t.Errorf("ComputeRequestHash() = %v, want %v", hash, expectedHash)

--- a/enclave/auction_test.go
+++ b/enclave/auction_test.go
@@ -34,7 +34,7 @@ func TestProcessAuction_ZeroBids(t *testing.T) {
 	req := enclaveapi.EnclaveAuctionRequest{
 		Type:      "auction_request",
 		AuctionID: "test_auction_zero_bids",
-		RoundID:   1,
+		RoundID:   "test_auction_zero_bids-1",
 		Bids:      []enclaveapi.EncryptedCoreBid{}, // No bids
 		Timestamp: time.Now(),
 	}
@@ -59,7 +59,7 @@ func TestProcessAuction_OneBid(t *testing.T) {
 	req := enclaveapi.EnclaveAuctionRequest{
 		Type:      "auction_request",
 		AuctionID: "test_auction_one_bid",
-		RoundID:   1,
+		RoundID:   "test_auction_one_bid-1",
 		Bids: []enclaveapi.EncryptedCoreBid{
 			{CoreBid: core.CoreBid{ID: "bid1", Bidder: "bidder_a", Price: 2.50, Currency: "USD"}},
 		},
@@ -95,7 +95,7 @@ func TestProcessAuction_TwoBids(t *testing.T) {
 	req := enclaveapi.EnclaveAuctionRequest{
 		Type:      "auction_request",
 		AuctionID: "test_auction_two_bids",
-		RoundID:   1,
+		RoundID:   "test_auction_two_bids-1",
 		Bids: []enclaveapi.EncryptedCoreBid{
 			{CoreBid: core.CoreBid{ID: "bid1", Bidder: "bidder_a", Price: 2.50, Currency: "USD"}},
 			{CoreBid: core.CoreBid{ID: "bid2", Bidder: "bidder_b", Price: 3.00, Currency: "USD"}},
@@ -141,7 +141,7 @@ func TestProcessAuction_ThreeBids(t *testing.T) {
 	req := enclaveapi.EnclaveAuctionRequest{
 		Type:      "auction_request",
 		AuctionID: "test_auction_three_bids",
-		RoundID:   1,
+		RoundID:   "test_auction_three_bids-1",
 		Bids: []enclaveapi.EncryptedCoreBid{
 			{CoreBid: core.CoreBid{ID: "bid1", Bidder: "bidder_a", Price: 2.50, Currency: "USD"}},
 			{CoreBid: core.CoreBid{ID: "bid2", Bidder: "bidder_b", Price: 3.00, Currency: "USD"}},
@@ -256,7 +256,7 @@ func TestProcessAuction_BidFloorEnforcement(t *testing.T) {
 	req := enclaveapi.EnclaveAuctionRequest{
 		Type:      "auction_request",
 		AuctionID: "test_auction_floor_enforcement",
-		RoundID:   1,
+		RoundID:   "test_auction_floor_enforcement-1",
 		Bids: []enclaveapi.EncryptedCoreBid{
 			{CoreBid: core.CoreBid{ID: "bid1", Bidder: "bidder_a", Price: 3.00, Currency: "USD"}}, // Above floor
 			{CoreBid: core.CoreBid{ID: "bid2", Bidder: "bidder_b", Price: 2.50, Currency: "USD"}}, // At floor
@@ -301,7 +301,7 @@ func TestProcessAuction_BidFloorAllRejected(t *testing.T) {
 	req := enclaveapi.EnclaveAuctionRequest{
 		Type:      "auction_request",
 		AuctionID: "test_auction_floor_all_rejected",
-		RoundID:   1,
+		RoundID:   "test_auction_floor_all_rejected-1",
 		Bids: []enclaveapi.EncryptedCoreBid{
 			{CoreBid: core.CoreBid{ID: "bid1", Bidder: "bidder_a", Price: 2.00, Currency: "USD"}},
 			{CoreBid: core.CoreBid{ID: "bid2", Bidder: "bidder_b", Price: 1.50, Currency: "USD"}},
@@ -350,7 +350,7 @@ func TestAuctionTokenValidation_WithValidToken(t *testing.T) {
 	req := enclaveapi.EnclaveAuctionRequest{
 		Type:      "auction_request",
 		AuctionID: "test_auction_valid_token",
-		RoundID:   1,
+		RoundID:   "test_auction_valid_token-1",
 		Bids: []enclaveapi.EncryptedCoreBid{
 			{
 				CoreBid: core.CoreBid{ID: "bid1", Bidder: "bidder1", Price: 0.0, Currency: "USD"},
@@ -391,7 +391,7 @@ func TestAuctionTokenValidation_WithInvalidToken(t *testing.T) {
 	req := enclaveapi.EnclaveAuctionRequest{
 		Type:      "auction_request",
 		AuctionID: "test_auction_invalid_token",
-		RoundID:   1,
+		RoundID:   "test_auction_invalid_token-1",
 		Bids: []enclaveapi.EncryptedCoreBid{
 			{
 				CoreBid: core.CoreBid{ID: "bid1", Bidder: "bidder1", Price: 0.0, Currency: "USD"},
@@ -432,7 +432,7 @@ func TestAuctionTokenValidation_WithConsumedToken(t *testing.T) {
 	req := enclaveapi.EnclaveAuctionRequest{
 		Type:      "auction_request",
 		AuctionID: "test_auction_consumed_token",
-		RoundID:   1,
+		RoundID:   "test_auction_consumed_token-1",
 		Bids: []enclaveapi.EncryptedCoreBid{
 			{
 				CoreBid: core.CoreBid{ID: "bid1", Bidder: "bidder1", Price: 0.0, Currency: "USD"},
@@ -468,7 +468,7 @@ func TestAuctionTokenValidation_WithoutToken(t *testing.T) {
 	req := enclaveapi.EnclaveAuctionRequest{
 		Type:      "auction_request",
 		AuctionID: "test_auction_no_token",
-		RoundID:   1,
+		RoundID:   "test_auction_no_token-1",
 		Bids: []enclaveapi.EncryptedCoreBid{
 			{
 				CoreBid: core.CoreBid{ID: "bid1", Bidder: "bidder1", Price: 0.0, Currency: "USD"},
@@ -512,7 +512,7 @@ func TestAuctionTokenValidation_MultipleBidsWithTokens(t *testing.T) {
 	req := enclaveapi.EnclaveAuctionRequest{
 		Type:      "auction_request",
 		AuctionID: "test_auction_multiple_tokens",
-		RoundID:   1,
+		RoundID:   "test_auction_multiple_tokens-1",
 		Bids: []enclaveapi.EncryptedCoreBid{
 			{
 				CoreBid: core.CoreBid{ID: "bid1", Bidder: "bidder1", Price: 0.0, Currency: "USD"},
@@ -581,7 +581,7 @@ func TestAuctionTokenValidation_MixedValidInvalidTokens(t *testing.T) {
 	req := enclaveapi.EnclaveAuctionRequest{
 		Type:      "auction_request",
 		AuctionID: "test_auction_mixed_tokens",
-		RoundID:   1,
+		RoundID:   "test_auction_mixed_tokens-1",
 		Bids: []enclaveapi.EncryptedCoreBid{
 			{
 				CoreBid: core.CoreBid{ID: "bid1", Bidder: "bidder1", Price: 0.0, Currency: "USD"},
@@ -648,7 +648,7 @@ func TestEndToEndTokenFlow(t *testing.T) {
 	req := enclaveapi.EnclaveAuctionRequest{
 		Type:      "auction_request",
 		AuctionID: "test_end_to_end",
-		RoundID:   1,
+		RoundID:   "test_end_to_end-1",
 		Bids: []enclaveapi.EncryptedCoreBid{
 			{
 				CoreBid: core.CoreBid{ID: "bid1", Bidder: "bidder1", Price: 0.0, Currency: "USD"},
@@ -675,7 +675,7 @@ func TestEndToEndTokenFlow(t *testing.T) {
 	req2 := enclaveapi.EnclaveAuctionRequest{
 		Type:      "auction_request",
 		AuctionID: "test_replay_attack",
-		RoundID:   1,
+		RoundID:   "test_replay_attack-1",
 		Bids: []enclaveapi.EncryptedCoreBid{
 			{
 				CoreBid: core.CoreBid{ID: "bid1", Bidder: "bidder1", Price: 0.0, Currency: "USD"},
@@ -719,7 +719,7 @@ func TestAuctionTokenValidation_MultipleBidsSameToken(t *testing.T) {
 	req := enclaveapi.EnclaveAuctionRequest{
 		Type:      "auction_request",
 		AuctionID: "test_auction_shared_token",
-		RoundID:   1,
+		RoundID:   "test_auction_shared_token-1",
 		Bids: []enclaveapi.EncryptedCoreBid{
 			{
 				CoreBid: core.CoreBid{ID: "bid1", Bidder: "bidder1", Price: 0.0, Currency: "USD"},
@@ -773,7 +773,7 @@ func TestProcessAuction_BidFloorZero(t *testing.T) {
 	req := enclaveapi.EnclaveAuctionRequest{
 		Type:      "auction_request",
 		AuctionID: "test_auction_floor_zero",
-		RoundID:   1,
+		RoundID:   "test_auction_floor_zero-1",
 		Bids: []enclaveapi.EncryptedCoreBid{
 			{CoreBid: core.CoreBid{ID: "bid1", Bidder: "bidder_a", Price: 3.00, Currency: "USD"}},
 			{CoreBid: core.CoreBid{ID: "bid2", Bidder: "bidder_b", Price: 0.50, Currency: "USD"}},
@@ -805,7 +805,7 @@ func TestProcessAuction_BidFloorWithAdjustments(t *testing.T) {
 	req := enclaveapi.EnclaveAuctionRequest{
 		Type:      "auction_request",
 		AuctionID: "test_auction_floor_with_adjustments",
-		RoundID:   1,
+		RoundID:   "test_auction_floor_with_adjustments-1",
 		Bids: []enclaveapi.EncryptedCoreBid{
 			{CoreBid: core.CoreBid{ID: "bid1", Bidder: "bidder_a", Price: 3.00, Currency: "USD"}},
 			{CoreBid: core.CoreBid{ID: "bid2", Bidder: "bidder_b", Price: 2.00, Currency: "USD"}}, // Below floor before adjustment
@@ -849,7 +849,7 @@ func TestProcessAuction_NegativeFloorRejected(t *testing.T) {
 	req := enclaveapi.EnclaveAuctionRequest{
 		Type:      "auction_request",
 		AuctionID: "test_auction_negative_floor",
-		RoundID:   1,
+		RoundID:   "test_auction_negative_floor-1",
 		Bids: []enclaveapi.EncryptedCoreBid{
 			{CoreBid: core.CoreBid{ID: "bid1", Bidder: "bidder_a", Price: 3.00, Currency: "USD"}},
 		},

--- a/enclave/proofs_test.go
+++ b/enclave/proofs_test.go
@@ -66,7 +66,7 @@ func TestGenerateNonce(t *testing.T) {
 func TestCalculateRequestHash(t *testing.T) {
 	req := enclaveapi.EnclaveAuctionRequest{
 		AuctionID: "auction_123",
-		RoundID:   2,
+		RoundID:   "auction_123-2",
 	}
 	nonce := "test_nonce"
 
@@ -102,7 +102,7 @@ func TestCalculateAdjustmentFactorsHash(t *testing.T) {
 func TestGenerateAttestation(t *testing.T) {
 	req := enclaveapi.EnclaveAuctionRequest{
 		AuctionID: "test_auction",
-		RoundID:   1,
+		RoundID:   "test_auction-1",
 		Bids: []enclaveapi.EncryptedCoreBid{
 			{CoreBid: core.CoreBid{ID: "bid1", Bidder: "bidder_a", Price: 2.50}},
 		},
@@ -126,7 +126,7 @@ func TestGenerateAttestationWithMock(t *testing.T) {
 	req := enclaveapi.EnclaveAuctionRequest{
 		Type:      "auction_request",
 		AuctionID: "test_auction_mock",
-		RoundID:   1,
+		RoundID:   "test_auction_mock-1",
 		Bids: []enclaveapi.EncryptedCoreBid{
 			{CoreBid: core.CoreBid{ID: "bid1", Bidder: "bidder_a", Price: 2.50, Currency: "USD"}},
 		},
@@ -174,7 +174,7 @@ func TestGenerateAttestationWithEncryptedBids(t *testing.T) {
 	req := enclaveapi.EnclaveAuctionRequest{
 		Type:      "auction_request",
 		AuctionID: "test_auction_encrypted_bids",
-		RoundID:   1,
+		RoundID:   "test_auction_encrypted_bids-1",
 		Bids: []enclaveapi.EncryptedCoreBid{
 			// Encrypted bid with EncryptedPrice populated
 			{
@@ -427,7 +427,7 @@ func TestGenerateAttestationWithMixedBidTypes(t *testing.T) {
 	req := enclaveapi.EnclaveAuctionRequest{
 		Type:      "auction_request",
 		AuctionID: "test_auction_mixed_scenario",
-		RoundID:   1,
+		RoundID:   "test_auction_mixed_scenario-1",
 		Bids: []enclaveapi.EncryptedCoreBid{
 			// Unencrypted bid 1 - Lower price, should lose
 			{CoreBid: core.CoreBid{ID: "unencrypted_bid_1", Bidder: "plaintext_bidder_a", Price: 2.25, Currency: "USD"}},
@@ -509,7 +509,7 @@ func TestGenerateAttestationWithMixedBidTypes(t *testing.T) {
 	userData := attestationDoc.UserData
 	check.NotNil(t, userData)
 	check.Equal(t, "test_auction_mixed_scenario", userData.AuctionID)
-	check.Equal(t, 1, userData.RoundID)
+	check.Equal(t, "test_auction_mixed_scenario-1", userData.RoundID)
 
 	// Critical test: Winner and runner-up are both from encrypted bids
 	check.NotNil(t, userData.Winner)

--- a/enclaveapi/types.go
+++ b/enclaveapi/types.go
@@ -102,7 +102,7 @@ type CoreBidWithoutBidder struct {
 // AuctionAttestationUserData represents the auction-specific data embedded in the attestation
 type AuctionAttestationUserData struct {
 	AuctionID              string                `json:"auction_id"`
-	RoundID                int                   `json:"round_id"`
+	RoundID                string                `json:"round_id"`
 	BidHashes              []string              `json:"bid_hashes"`
 	RequestHash            string                `json:"request_hash"`
 	AdjustmentFactorsHash  string                `json:"adjustment_factors_hash"`
@@ -138,7 +138,7 @@ type EncryptedCoreBid struct {
 type EnclaveAuctionRequest struct {
 	Type              string             `json:"type"`
 	AuctionID         string             `json:"auction_id"`
-	RoundID           int                `json:"round_id"`
+	RoundID           string             `json:"round_id"`
 	Bids              []EncryptedCoreBid `json:"bids"`
 	AdjustmentFactors map[string]float64 `json:"adjustment_factors"`
 	BidFloor          float64            `json:"bid_floor"`


### PR DESCRIPTION
Idea is to have unique auction round id, that would hold auction id within. 

For example, if auctionID value (that is [BidRequest.id](https://iabtechlab.com/wp-content/uploads/2022/04/OpenRTB-2-6_FINAL.pdf#page=17&zoom=100,77,222)) is:
```
cloudx-auction-sim-1768492001181
```
Then auction round id, for that auction first round would be:
```
cloudx-auction-sim-1768492001181-1
```

Opened improved solution [PR here](https://github.com/cloudx-io/openauction/pull/30)