### PR TITLE
Add CPU and memory metrics to enclave ping response

### DIFF
--- a/enclave/server.go
+++ b/enclave/server.go
@@ -130,6 +130,7 @@ func (s *EnclaveServer) handleConnection(conn net.Conn) {
 			"type":      "pong",
 			"message":   "TEE server is healthy",
 			"timestamp": time.Now().Unix(),
+			"system":    getSystemInfoOrNil(),
 		}
 		log.Printf("INFO: Responding to ping with pong")
 

--- a/enclave/sysinfo.go
+++ b/enclave/sysinfo.go
@@ -1,0 +1,208 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"log"
+	"math"
+	"os"
+	"runtime"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type SystemInfo struct {
+	MemTotalBytes   uint64  `json:"mem_total_bytes"`
+	MemUsedBytes    uint64  `json:"mem_used_bytes"`
+	MemUsagePercent float64 `json:"mem_usage_percent"`
+	CPUUsagePercent float64 `json:"cpu_usage_percent"`
+	NumCPUs         int     `json:"num_cpus"`
+}
+
+const cpuSampleInterval = 100 * time.Millisecond
+
+func getSystemInfoOrNil() *SystemInfo {
+	info, err := GetSystemInfo()
+	if err != nil {
+		log.Printf("WARN: Failed to collect system info: %v", err)
+		return nil
+	}
+	return info
+}
+
+func GetSystemInfo() (*SystemInfo, error) {
+	mem, err := readMemInfo("/proc/meminfo")
+	if err != nil {
+		return nil, fmt.Errorf("reading meminfo: %w", err)
+	}
+
+	cpuPct, err := sampleCPUUsage("/proc/stat", cpuSampleInterval)
+	if err != nil {
+		return nil, fmt.Errorf("reading cpu stats: %w", err)
+	}
+
+	return &SystemInfo{
+		MemTotalBytes:   mem.totalBytes,
+		MemUsedBytes:    mem.usedBytes,
+		MemUsagePercent: mem.usagePercent,
+		CPUUsagePercent: cpuPct,
+		NumCPUs:         runtime.NumCPU(),
+	}, nil
+}
+
+type memStats struct {
+	totalBytes   uint64
+	usedBytes    uint64
+	usagePercent float64
+}
+
+func readMemInfo(path string) (*memStats, error) {
+	fields, err := parseKeyValueKB(path, "MemTotal", "MemAvailable", "MemFree", "Buffers", "Cached")
+	if err != nil {
+		return nil, err
+	}
+
+	total, ok := fields["MemTotal"]
+	if !ok || total == 0 {
+		return nil, fmt.Errorf("MemTotal not found or zero in %s", path)
+	}
+
+	available, hasAvailable := fields["MemAvailable"]
+	if !hasAvailable {
+		// Kernel <3.14 fallback
+		free := fields["MemFree"]
+		buffers := fields["Buffers"]
+		cached := fields["Cached"]
+		available = free + buffers + cached
+	}
+
+	totalBytes := total * 1024
+	var usedBytes uint64
+	if total > available {
+		usedBytes = (total - available) * 1024
+	}
+	pct := float64(usedBytes) / float64(totalBytes) * 100
+	pct = math.Round(pct*10) / 10
+
+	return &memStats{
+		totalBytes:   totalBytes,
+		usedBytes:    usedBytes,
+		usagePercent: pct,
+	}, nil
+}
+
+// parseKeyValueKB reads /proc/meminfo-style files and returns values in kB for
+// the requested keys.
+func parseKeyValueKB(path string, keys ...string) (map[string]uint64, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = f.Close() }()
+
+	want := make(map[string]bool, len(keys))
+	for _, k := range keys {
+		want[k] = true
+	}
+
+	result := make(map[string]uint64, len(keys))
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := scanner.Text()
+		key, val, ok := parseMemInfoLine(line)
+		if ok && want[key] {
+			result[key] = val
+		}
+	}
+	return result, scanner.Err()
+}
+
+// parseMemInfoLine parses a single line like "MemTotal:       16384 kB" and
+// returns (key, valueInKB, ok).
+func parseMemInfoLine(line string) (string, uint64, bool) {
+	colon := strings.IndexByte(line, ':')
+	if colon < 0 {
+		return "", 0, false
+	}
+	key := line[:colon]
+	rest := strings.TrimSpace(line[colon+1:])
+
+	rest = strings.TrimSuffix(rest, " kB")
+	val, err := strconv.ParseUint(rest, 10, 64)
+	if err != nil {
+		return "", 0, false
+	}
+	return key, val, true
+}
+
+type cpuTicks struct {
+	total uint64
+	idle  uint64
+}
+
+func readCPUTicks(path string) (*cpuTicks, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = f.Close() }()
+
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if strings.HasPrefix(line, "cpu ") {
+			return parseCPULine(line)
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+	return nil, fmt.Errorf("no aggregate cpu line found in %s", path)
+}
+
+// parseCPULine parses the aggregate "cpu  ..." line from /proc/stat.
+// Fields: user nice system idle iowait irq softirq steal [guest guest_nice]
+func parseCPULine(line string) (*cpuTicks, error) {
+	fields := strings.Fields(line)
+	if len(fields) < 5 {
+		return nil, fmt.Errorf("unexpected cpu line format: %q", line)
+	}
+
+	var total, idle uint64
+	for i, f := range fields[1:] {
+		v, err := strconv.ParseUint(f, 10, 64)
+		if err != nil {
+			return nil, fmt.Errorf("parsing field %d of cpu line: %w", i, err)
+		}
+		total += v
+		if i == 3 { // idle is the 4th value (0-indexed field 3)
+			idle = v
+		}
+	}
+	return &cpuTicks{total: total, idle: idle}, nil
+}
+
+func sampleCPUUsage(path string, interval time.Duration) (float64, error) {
+	t1, err := readCPUTicks(path)
+	if err != nil {
+		return 0, err
+	}
+
+	time.Sleep(interval)
+
+	t2, err := readCPUTicks(path)
+	if err != nil {
+		return 0, err
+	}
+
+	totalDelta := t2.total - t1.total
+	idleDelta := t2.idle - t1.idle
+
+	if totalDelta == 0 {
+		return 0, nil
+	}
+
+	pct := float64(totalDelta-idleDelta) / float64(totalDelta) * 100
+	return math.Round(pct*10) / 10, nil
+}

--- a/enclave/sysinfo_test.go
+++ b/enclave/sysinfo_test.go
@@ -1,0 +1,175 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/peterldowns/testy/assert"
+)
+
+func TestParseMemInfoLine(t *testing.T) {
+	tests := []struct {
+		line    string
+		wantKey string
+		wantVal uint64
+		wantOK  bool
+	}{
+		{"MemTotal:       16384000 kB", "MemTotal", 16384000, true},
+		{"MemAvailable:    8192000 kB", "MemAvailable", 8192000, true},
+		{"MemFree:         4096000 kB", "MemFree", 4096000, true},
+		{"Buffers:          512000 kB", "Buffers", 512000, true},
+		{"Cached:          2048000 kB", "Cached", 2048000, true},
+		{"bogus line", "", 0, false},
+		{"NoValue:", "", 0, false},
+	}
+
+	for _, tt := range tests {
+		key, val, ok := parseMemInfoLine(tt.line)
+		assert.Equal(t, tt.wantOK, ok)
+		if ok {
+			assert.Equal(t, tt.wantKey, key)
+			assert.Equal(t, tt.wantVal, val)
+		}
+	}
+}
+
+func writeFixture(t *testing.T, name, content string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), name)
+	err := os.WriteFile(path, []byte(content), 0o644)
+	assert.NoError(t, err)
+	return path
+}
+
+func TestReadMemInfo(t *testing.T) {
+	content := `MemTotal:       16384000 kB
+MemFree:         4096000 kB
+MemAvailable:    8192000 kB
+Buffers:          512000 kB
+Cached:          2048000 kB
+SwapTotal:       2097152 kB
+SwapFree:        2097152 kB
+`
+	path := writeFixture(t, "meminfo", content)
+
+	mem, err := readMemInfo(path)
+	assert.NoError(t, err)
+
+	assert.Equal(t, uint64(16384000*1024), mem.totalBytes)
+	assert.Equal(t, uint64((16384000-8192000)*1024), mem.usedBytes)
+	assert.Equal(t, 50.0, mem.usagePercent)
+}
+
+func TestReadMemInfo_NoMemAvailable(t *testing.T) {
+	content := `MemTotal:       16384000 kB
+MemFree:         4096000 kB
+Buffers:          512000 kB
+Cached:          2048000 kB
+`
+	path := writeFixture(t, "meminfo", content)
+
+	mem, err := readMemInfo(path)
+	assert.NoError(t, err)
+
+	// Fallback: available = MemFree + Buffers + Cached = 6656000
+	expectedUsed := uint64((16384000 - 6656000) * 1024)
+	assert.Equal(t, uint64(16384000*1024), mem.totalBytes)
+	assert.Equal(t, expectedUsed, mem.usedBytes)
+}
+
+func TestReadMemInfo_MissingMemTotal(t *testing.T) {
+	content := `MemFree:         4096000 kB
+MemAvailable:    8192000 kB
+`
+	path := writeFixture(t, "meminfo", content)
+
+	_, err := readMemInfo(path)
+	assert.Error(t, err)
+}
+
+func TestReadMemInfo_FileNotFound(t *testing.T) {
+	_, err := readMemInfo("/nonexistent/meminfo")
+	assert.Error(t, err)
+}
+
+func TestParseCPULine(t *testing.T) {
+	// Fields: user nice system idle iowait irq softirq steal
+	line := "cpu  100 20 30 500 10 5 3 2"
+	ticks, err := parseCPULine(line)
+	assert.NoError(t, err)
+
+	// total = 100+20+30+500+10+5+3+2 = 670
+	assert.Equal(t, uint64(670), ticks.total)
+	// idle is the 4th field (index 3) = 500
+	assert.Equal(t, uint64(500), ticks.idle)
+}
+
+func TestParseCPULine_WithGuestFields(t *testing.T) {
+	line := "cpu  100 20 30 500 10 5 3 2 50 25"
+	ticks, err := parseCPULine(line)
+	assert.NoError(t, err)
+
+	// total = 100+20+30+500+10+5+3+2+50+25 = 745
+	assert.Equal(t, uint64(745), ticks.total)
+	assert.Equal(t, uint64(500), ticks.idle)
+}
+
+func TestParseCPULine_TooFewFields(t *testing.T) {
+	line := "cpu  100 20 30"
+	_, err := parseCPULine(line)
+	assert.Error(t, err)
+}
+
+func TestReadCPUTicks(t *testing.T) {
+	content := `cpu  100 20 30 500 10 5 3 2
+cpu0 50 10 15 250 5 3 1 1
+cpu1 50 10 15 250 5 2 2 1
+`
+	path := writeFixture(t, "stat", content)
+
+	ticks, err := readCPUTicks(path)
+	assert.NoError(t, err)
+	assert.Equal(t, uint64(670), ticks.total)
+	assert.Equal(t, uint64(500), ticks.idle)
+}
+
+func TestReadCPUTicks_NoCPULine(t *testing.T) {
+	content := `procs_running 2
+procs_blocked 0
+`
+	path := writeFixture(t, "stat", content)
+
+	_, err := readCPUTicks(path)
+	assert.Error(t, err)
+}
+
+func TestReadCPUTicks_FileNotFound(t *testing.T) {
+	_, err := readCPUTicks("/nonexistent/stat")
+	assert.Error(t, err)
+}
+
+func TestReadMemInfo_FullyUsed(t *testing.T) {
+	content := `MemTotal:       1024 kB
+MemAvailable:      0 kB
+`
+	path := writeFixture(t, "meminfo", content)
+
+	mem, err := readMemInfo(path)
+	assert.NoError(t, err)
+	assert.Equal(t, uint64(1024*1024), mem.totalBytes)
+	assert.Equal(t, uint64(1024*1024), mem.usedBytes)
+	assert.Equal(t, 100.0, mem.usagePercent)
+}
+
+func TestReadMemInfo_NothingUsed(t *testing.T) {
+	content := `MemTotal:       1024 kB
+MemAvailable:   1024 kB
+`
+	path := writeFixture(t, "meminfo", content)
+
+	mem, err := readMemInfo(path)
+	assert.NoError(t, err)
+	assert.Equal(t, uint64(0), mem.usedBytes)
+	assert.Equal(t, 0.0, mem.usagePercent)
+}


### PR DESCRIPTION
## Summary

- Enclave ping/pong now reports CPU and memory utilization by reading `/proc/meminfo` and `/proc/stat`
- Metrics are included as an optional `"system"` key in the pong JSON; if procfs is unavailable the pong still returns healthy without it
- No new dependencies -- uses only the standard library to parse procfs

## Example response

```json
{
  "type": "pong",
  "message": "TEE server is healthy",
  "timestamp": 1709500000,
  "system": {
    "mem_total_bytes": 1073741824,
    "mem_used_bytes": 536870912,
    "mem_usage_percent": 50.0,
    "cpu_usage_percent": 23.5,
    "num_cpus": 2
  }
}
```

## Test plan

- [x] All existing tests pass (`go test ./...`)
- [x] 13 new unit tests for procfs parsing using temp-file fixtures (run on macOS, no live procfs needed)

Made with [Cursor](https://cursor.com)