### PR TITLE
Fix guest/guest_nice double-counting in CPU usage calculation

### DIFF
--- a/enclave/sysinfo.go
+++ b/enclave/sysinfo.go
@@ -163,20 +163,28 @@ func readCPUTicks(path string) (*cpuTicks, error) {
 
 // parseCPULine parses the aggregate "cpu  ..." line from /proc/stat.
 // Fields: user nice system idle iowait irq softirq steal [guest guest_nice]
+//
+// guest and guest_nice are already accounted for in user and nice, so we
+// only sum the first 8 fields to avoid double-counting.
 func parseCPULine(line string) (*cpuTicks, error) {
 	fields := strings.Fields(line)
 	if len(fields) < 5 {
 		return nil, fmt.Errorf("unexpected cpu line format: %q", line)
 	}
 
+	numFields := len(fields) - 1 // exclude "cpu" label
+	if numFields > 8 {
+		numFields = 8
+	}
+
 	var total, idle uint64
-	for i, f := range fields[1:] {
+	for i, f := range fields[1 : 1+numFields] {
 		v, err := strconv.ParseUint(f, 10, 64)
 		if err != nil {
 			return nil, fmt.Errorf("parsing field %d of cpu line: %w", i, err)
 		}
 		total += v
-		if i == 3 { // idle is the 4th value (0-indexed field 3)
+		if i == 3 {
 			idle = v
 		}
 	}

--- a/enclave/sysinfo_test.go
+++ b/enclave/sysinfo_test.go
@@ -106,12 +106,14 @@ func TestParseCPULine(t *testing.T) {
 }
 
 func TestParseCPULine_WithGuestFields(t *testing.T) {
+	// guest and guest_nice (50, 25) are already included in user and nice,
+	// so they must be excluded to avoid double-counting.
 	line := "cpu  100 20 30 500 10 5 3 2 50 25"
 	ticks, err := parseCPULine(line)
 	assert.NoError(t, err)
 
-	// total = 100+20+30+500+10+5+3+2+50+25 = 745
-	assert.Equal(t, uint64(745), ticks.total)
+	// total = 100+20+30+500+10+5+3+2 = 670 (guest fields excluded)
+	assert.Equal(t, uint64(670), ticks.total)
 	assert.Equal(t, uint64(500), ticks.idle)
 }
 


### PR DESCRIPTION
## Summary

- `parseCPULine` was summing all fields from `/proc/stat` including `guest` and `guest_nice`, which the Linux kernel already includes in `user` and `nice` -- this double-counts CPU time on kernels that report those fields
- Now caps parsing at the first 8 fields (user through steal)
- Follow-up to #33

## Test plan

- [x] Updated `TestParseCPULine_WithGuestFields` to assert guest fields are excluded from the total
- [x] Full test suite passes

Made with [Cursor](https://cursor.com)