### PR TITLE
Stop forwarding session credentials over SSH to EIF builder

### DIFF
--- a/.github/workflows/eif-build.yml
+++ b/.github/workflows/eif-build.yml
@@ -244,10 +244,7 @@ jobs:
           ssh -i /tmp/eif-builder-key.pem \
               -o StrictHostKeyChecking=no \
               ec2-user@${{ steps.launch-instance.outputs.public_ip }} \
-              "sudo AWS_ACCESS_KEY_ID='${AWS_ACCESS_KEY_ID}' \
-                    AWS_SECRET_ACCESS_KEY='${AWS_SECRET_ACCESS_KEY}' \
-                    AWS_SESSION_TOKEN='${AWS_SESSION_TOKEN}' \
-                    bash ~/scripts/build-eif-ci.sh \
+              "sudo bash ~/scripts/build-eif-ci.sh \
                     '${{ steps.image-uri.outputs.image_uri }}' \
                     '/tmp/auction.eif' \
                     '${{ env.AWS_REGION }}'"

--- a/enclave/scripts/build-eif-ci.sh
+++ b/enclave/scripts/build-eif-ci.sh
@@ -12,8 +12,8 @@ set -euo pipefail
 #   OUTPUT_EIF_PATH: Path where the EIF file should be written
 #   AWS_REGION: (Optional) AWS region, defaults to us-east-1
 #
-# Environment Variables:
-#   AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_SESSION_TOKEN: AWS credentials
+# AWS credentials are provided by the EC2 instance profile (eif-builder-instance)
+# via the instance metadata service (IMDS).
 #
 # Outputs:
 #   - EIF file at OUTPUT_EIF_PATH
@@ -71,8 +71,7 @@ validate_prerequisites() {
     log "✓ Nitro CLI available: $(nitro-cli --version 2>&1 | head -n1 || echo 'version unknown')"
 
     if ! aws sts get-caller-identity &> /dev/null; then
-        log_error "AWS credentials not configured"
-        log_error "Set AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY or attach IAM instance profile"
+        log_error "AWS credentials not configured — verify the EC2 instance profile is attached"
         return 1
     fi
     log "✓ AWS credentials configured"


### PR DESCRIPTION
## Summary

- Remove `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` / `AWS_SESSION_TOKEN` env var forwarding from the SSH command in the EIF build step
- The EC2 instance already has the `eif-builder-instance` IAM instance profile attached with ECR pull permissions, so credentials are available via IMDS without explicit forwarding
- Update `build-eif-ci.sh` documentation to reflect the instance profile as the expected credential source

Made with [Cursor](https://cursor.com)