### PR TITLE
Update GitHub Actions to Node.js 24

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -12,15 +12,15 @@ jobs:
       id-token: write # for AWS OIDC authentication
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: ${{ github.event.workflow_run.head_sha }}
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version: "1.25.1"
       - name: Configure AWS credentials
         if: github.event.workflow_run.head_branch == 'main'
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/github-actions-ecr-push
           aws-region: us-east-1
@@ -41,7 +41,7 @@ jobs:
       - name: docker set metadata
         id: dockermetadata
         # https://github.com/docker/metadata-action
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: |
             ${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.us-east-1.amazonaws.com/cloudx-io/openauction/enclave
@@ -59,10 +59,10 @@ jobs:
             type=raw,value=${{ env.CLOUDX_VERSION }}-commit.${{ env.CLOUDX_COMMIT }}
             # "latest"
             type=raw,value=latest
-      - uses: docker/setup-buildx-action@v3.11.1
+      - uses: docker/setup-buildx-action@v4
         with:
           platforms: linux/amd64
-      - uses: docker/build-push-action@v6.18.0
+      - uses: docker/build-push-action@v7
         with:
           context: .
           file: enclave/Dockerfile

--- a/.github/workflows/eif-build.yml
+++ b/.github/workflows/eif-build.yml
@@ -80,7 +80,7 @@ jobs:
     
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ github.event.workflow_run.head_sha || github.sha }}
       
@@ -97,7 +97,7 @@ jobs:
           echo "Building EIF for commit: ${COMMIT_SHA}"
       
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           # OIDC role for EIF building workflow (needs EC2 + ECR permissions)
           role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/eif-builder-workflow
@@ -312,7 +312,7 @@ jobs:
           oras tag "${REGISTRY}/${REPO}:${COMMIT_SHA}" "${COMMIT_SHORT}"
       
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: eif-${{ steps.set-sha.outputs.commit_short }}
           path: |
@@ -383,13 +383,13 @@ jobs:
     steps:
       - name: Generate GitHub App token
         id: app-token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ env.GH_APP_ID }}
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           token: ${{ steps.app-token.outputs.token }}
 

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -10,8 +10,8 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v5
+      - uses: actions/setup-go@v6
         with:
           go-version: "1.25.1"
       - name: Test
@@ -21,12 +21,12 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v5
+      - uses: actions/setup-go@v6
         with:
           go-version: "1.25.1"
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v8.0.0
+        uses: golangci/golangci-lint-action@v9
         with:
           version: v2.5.0
       - name: go mod tidy


### PR DESCRIPTION
## Summary
- Bump all GitHub Actions to Node.js 24 versions to resolve deprecation warnings
- checkout v4->v5, configure-aws-credentials v4->v6, upload-artifact v4->v6, create-github-app-token v1->v3, setup-go v5->v6, golangci-lint-action v8->v9, docker/metadata-action v5->v6, docker/setup-buildx-action v3->v4, docker/build-push-action v6->v7

Made with [Cursor](https://cursor.com)