### PR TITLE
enclave: default automated EIF + image builds to arm64

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -3,33 +3,51 @@ on:
   workflow_run:
     workflows: ["Go"]
     types: [completed]
+  workflow_dispatch:
+    inputs:
+      architecture:
+        description: CPU architecture to build.
+        type: choice
+        default: amd64
+        options:
+          - amd64
+          - arm64
 
 jobs:
   enclave:
     # Only run if the Go workflow succeeded
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     permissions:
       id-token: write # for AWS OIDC authentication
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
         with:
-          ref: ${{ github.event.workflow_run.head_sha }}
+          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
       - uses: actions/setup-go@v6
         with:
           go-version: "1.25.1"
       - name: Configure AWS credentials
-        if: github.event.workflow_run.head_branch == 'main'
+        if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.head_branch == 'main'
         uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/github-actions-ecr-push
           aws-region: us-east-1
       - name: Login to Amazon ECR
-        if: github.event.workflow_run.head_branch == 'main'
+        if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.head_branch == 'main'
         uses: aws-actions/amazon-ecr-login@v2
-      - name: go build bin/enclave-linux-amd64
+      - name: docker set architecture env vars
         run: |
-          CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -ldflags '-extldflags "-static"' -tags netgo -o ./bin/tee-auction-enclave ./enclave
+          ARCHITECTURE="${{ github.event.inputs.architecture || 'amd64' }}"
+          echo "ARCHITECTURE=${ARCHITECTURE}" >> $GITHUB_ENV
+          if [ "${ARCHITECTURE}" = "arm64" ]; then
+            echo "IMAGE_TAG_SUFFIX=-arm64" >> $GITHUB_ENV
+          else
+            echo "IMAGE_TAG_SUFFIX=" >> $GITHUB_ENV
+          fi
+      - name: go build enclave binary
+        run: |
+          CGO_ENABLED=0 GOOS=linux GOARCH=${{ env.ARCHITECTURE }} go build -a -ldflags '-extldflags "-static"' -tags netgo -o ./bin/tee-auction-enclave ./enclave
       - name: docker set build tag env vars
         run: |
           VERSION="0.0.0"
@@ -52,23 +70,23 @@ jobs:
             org.opencontainers.image.source=https://github.com/cloudx-io/openauction
           tags: |
             # short sha of the commit
-            type=sha,prefix=,suffix=,format=short
+            type=sha,prefix=,suffix=${{ env.IMAGE_TAG_SUFFIX }},format=short
             # long sha of the commit
-            type=sha,prefix=,suffix=,format=long
+            type=sha,prefix=,suffix=${{ env.IMAGE_TAG_SUFFIX }},format=long
             # our version tag, like "0.0.0-commit.ABCDEF01"
-            type=raw,value=${{ env.CLOUDX_VERSION }}-commit.${{ env.CLOUDX_COMMIT }}
+            type=raw,value=${{ env.CLOUDX_VERSION }}-commit.${{ env.CLOUDX_COMMIT }}${{ env.IMAGE_TAG_SUFFIX }}
             # "latest"
-            type=raw,value=latest
+            type=raw,value=latest${{ env.IMAGE_TAG_SUFFIX }}
       - uses: docker/setup-buildx-action@v4
         with:
-          platforms: linux/amd64
+          platforms: linux/${{ env.ARCHITECTURE }}
       - uses: docker/build-push-action@v7
         with:
           context: .
           file: enclave/Dockerfile
-          platforms: linux/amd64
-          # Only push on main branch, not on PR branches
-          push: ${{ github.event.workflow_run.head_branch == 'main' }}
+          platforms: linux/${{ env.ARCHITECTURE }}
+          # Only push automated builds on main; manual dispatches are explicit.
+          push: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.head_branch == 'main' }}
           sbom: true
           provenance: mode=max
           tags: ${{ steps.dockermetadata.outputs.tags }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -27,15 +27,6 @@ jobs:
       - uses: actions/setup-go@v6
         with:
           go-version: "1.25.1"
-      - name: Configure AWS credentials
-        if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.head_branch == 'main'
-        uses: aws-actions/configure-aws-credentials@v6
-        with:
-          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/github-actions-ecr-push
-          aws-region: us-east-1
-      - name: Login to Amazon ECR
-        if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.head_branch == 'main'
-        uses: aws-actions/amazon-ecr-login@v2
       - name: docker set architecture env vars
         run: |
           ARCHITECTURE="${{ github.event.inputs.architecture || 'amd64' }}"
@@ -45,6 +36,25 @@ jobs:
           else
             echo "IMAGE_TAG_SUFFIX=" >> $GITHUB_ENV
           fi
+
+          PUBLISH_IMAGE=false
+          if [ "${{ github.event_name }}" = "workflow_run" ] && [ "${{ github.event.workflow_run.head_branch }}" = "main" ]; then
+            PUBLISH_IMAGE=true
+          elif [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            if [ "${{ github.ref }}" = "refs/heads/main" ] || [ "${ARCHITECTURE}" = "arm64" ]; then
+              PUBLISH_IMAGE=true
+            fi
+          fi
+          echo "PUBLISH_IMAGE=${PUBLISH_IMAGE}" >> $GITHUB_ENV
+      - name: Configure AWS credentials
+        if: env.PUBLISH_IMAGE == 'true'
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/github-actions-ecr-push
+          aws-region: us-east-1
+      - name: Login to Amazon ECR
+        if: env.PUBLISH_IMAGE == 'true'
+        uses: aws-actions/amazon-ecr-login@v2
       - name: go build enclave binary
         run: |
           CGO_ENABLED=0 GOOS=linux GOARCH=${{ env.ARCHITECTURE }} go build -a -ldflags '-extldflags "-static"' -tags netgo -o ./bin/tee-auction-enclave ./enclave
@@ -76,7 +86,7 @@ jobs:
             # our version tag, like "0.0.0-commit.ABCDEF01"
             type=raw,value=${{ env.CLOUDX_VERSION }}-commit.${{ env.CLOUDX_COMMIT }}${{ env.IMAGE_TAG_SUFFIX }}
             # "latest"
-            type=raw,value=latest${{ env.IMAGE_TAG_SUFFIX }}
+            type=raw,value=latest${{ env.IMAGE_TAG_SUFFIX }},enable=${{ github.event.workflow_run.head_branch == 'main' || github.ref == 'refs/heads/main' }}
       - uses: docker/setup-qemu-action@v3
         if: env.ARCHITECTURE == 'arm64'
       - uses: docker/setup-buildx-action@v4
@@ -87,8 +97,8 @@ jobs:
           context: .
           file: enclave/Dockerfile
           platforms: linux/${{ env.ARCHITECTURE }}
-          # Only push automated builds on main; manual dispatches are explicit.
-          push: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.head_branch == 'main' }}
+          # Non-main arm64 dispatches publish only commit/version-specific tags for EIF validation.
+          push: ${{ env.PUBLISH_IMAGE == 'true' }}
           sbom: true
           provenance: mode=max
           tags: ${{ steps.dockermetadata.outputs.tags }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -77,6 +77,8 @@ jobs:
             type=raw,value=${{ env.CLOUDX_VERSION }}-commit.${{ env.CLOUDX_COMMIT }}${{ env.IMAGE_TAG_SUFFIX }}
             # "latest"
             type=raw,value=latest${{ env.IMAGE_TAG_SUFFIX }}
+      - uses: docker/setup-qemu-action@v3
+        if: env.ARCHITECTURE == 'arm64'
       - uses: docker/setup-buildx-action@v4
         with:
           platforms: linux/${{ env.ARCHITECTURE }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -8,10 +8,10 @@ on:
       architecture:
         description: CPU architecture to build.
         type: choice
-        default: amd64
+        default: arm64
         options:
-          - amd64
           - arm64
+          - amd64
 
 jobs:
   enclave:
@@ -29,7 +29,9 @@ jobs:
           go-version: "1.25.1"
       - name: docker set architecture env vars
         run: |
-          ARCHITECTURE="${{ github.event.inputs.architecture || 'amd64' }}"
+          # arm64 is the default: automated workflow_run builds (no input) produce
+          # the arm64 image. amd64 is opt-in via workflow_dispatch.
+          ARCHITECTURE="${{ github.event.inputs.architecture || 'arm64' }}"
           echo "ARCHITECTURE=${ARCHITECTURE}" >> "$GITHUB_ENV"
           if [ "${ARCHITECTURE}" = "arm64" ]; then
             echo "IMAGE_TAG_SUFFIX=-arm64" >> "$GITHUB_ENV"

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -30,11 +30,11 @@ jobs:
       - name: docker set architecture env vars
         run: |
           ARCHITECTURE="${{ github.event.inputs.architecture || 'amd64' }}"
-          echo "ARCHITECTURE=${ARCHITECTURE}" >> $GITHUB_ENV
+          echo "ARCHITECTURE=${ARCHITECTURE}" >> "$GITHUB_ENV"
           if [ "${ARCHITECTURE}" = "arm64" ]; then
-            echo "IMAGE_TAG_SUFFIX=-arm64" >> $GITHUB_ENV
+            echo "IMAGE_TAG_SUFFIX=-arm64" >> "$GITHUB_ENV"
           else
-            echo "IMAGE_TAG_SUFFIX=" >> $GITHUB_ENV
+            echo "IMAGE_TAG_SUFFIX=" >> "$GITHUB_ENV"
           fi
 
           PUBLISH_IMAGE=false
@@ -45,7 +45,7 @@ jobs:
               PUBLISH_IMAGE=true
             fi
           fi
-          echo "PUBLISH_IMAGE=${PUBLISH_IMAGE}" >> $GITHUB_ENV
+          echo "PUBLISH_IMAGE=${PUBLISH_IMAGE}" >> "$GITHUB_ENV"
       - name: Configure AWS credentials
         if: env.PUBLISH_IMAGE == 'true'
         uses: aws-actions/configure-aws-credentials@v6
@@ -64,8 +64,8 @@ jobs:
           SHA="$(git rev-parse --short HEAD || echo 'unknown')"
           DIRTY="$(git diff --no-ext-diff --quiet --exit-code HEAD || echo '.dirty')"
           COMMIT="${SHA}${DIRTY}"
-          echo "CLOUDX_VERSION=${VERSION}" >> $GITHUB_ENV
-          echo "CLOUDX_COMMIT=${COMMIT}" >> $GITHUB_ENV
+          echo "CLOUDX_VERSION=${VERSION}" >> "$GITHUB_ENV"
+          echo "CLOUDX_COMMIT=${COMMIT}" >> "$GITHUB_ENV"
       - name: docker set metadata
         id: dockermetadata
         # https://github.com/docker/metadata-action

--- a/.github/workflows/eif-build.yml
+++ b/.github/workflows/eif-build.yml
@@ -119,6 +119,11 @@ jobs:
             --query 'sort_by(Images, &CreationDate)[-1].ImageId' \
             --output text)
 
+          if [ -z "${AMI_ID}" ] || [ "${AMI_ID}" = "None" ]; then
+            echo "::error::Failed to resolve AL2023 ${AMI_ARCH} builder AMI"
+            exit 1
+          fi
+
           echo "architecture=${ARCHITECTURE}" >> $GITHUB_OUTPUT
           echo "ami_id=${AMI_ID}" >> $GITHUB_OUTPUT
           echo "instance_type=${INSTANCE_TYPE}" >> $GITHUB_OUTPUT

--- a/.github/workflows/eif-build.yml
+++ b/.github/workflows/eif-build.yml
@@ -67,6 +67,7 @@ jobs:
       contents: read
     
     outputs:
+      architecture: ${{ steps.builder-arch.outputs.architecture }}
       pcr0: ${{ steps.extract-pcrs.outputs.pcr0 }}
       pcr1: ${{ steps.extract-pcrs.outputs.pcr1 }}
       pcr2: ${{ steps.extract-pcrs.outputs.pcr2 }}
@@ -415,7 +416,7 @@ jobs:
     name: Update PCR validation file
     runs-on: ubuntu-latest
     needs: build-eif
-    if: github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/main' && needs.build-eif.outputs.architecture == 'amd64'
     env:
       GH_APP_ID: '2665276'
 

--- a/.github/workflows/eif-build.yml
+++ b/.github/workflows/eif-build.yml
@@ -87,8 +87,8 @@ jobs:
           else
             COMMIT_SHA="${{ github.sha }}"
           fi
-          echo "commit_sha=${COMMIT_SHA}" >> $GITHUB_OUTPUT
-          echo "commit_short=${COMMIT_SHA:0:7}" >> $GITHUB_OUTPUT
+          echo "commit_sha=${COMMIT_SHA}" >> "$GITHUB_OUTPUT"
+          echo "commit_short=${COMMIT_SHA:0:7}" >> "$GITHUB_OUTPUT"
           echo "Building EIF for commit: ${COMMIT_SHA}"
       
       - name: Configure AWS credentials
@@ -124,9 +124,9 @@ jobs:
             exit 1
           fi
 
-          echo "architecture=${ARCHITECTURE}" >> $GITHUB_OUTPUT
-          echo "ami_id=${AMI_ID}" >> $GITHUB_OUTPUT
-          echo "instance_type=${INSTANCE_TYPE}" >> $GITHUB_OUTPUT
+          echo "architecture=${ARCHITECTURE}" >> "$GITHUB_OUTPUT"
+          echo "ami_id=${AMI_ID}" >> "$GITHUB_OUTPUT"
+          echo "instance_type=${INSTANCE_TYPE}" >> "$GITHUB_OUTPUT"
           echo "Using ${ARCHITECTURE} builder ${INSTANCE_TYPE} with AMI ${AMI_ID}"
       
       - name: Construct Docker image URI
@@ -150,7 +150,7 @@ jobs:
           fi
 
           IMAGE_URI="${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${{ env.AWS_REGION }}.amazonaws.com/cloudx-io/openauction/enclave:${IMAGE_TAG}"
-          echo "image_uri=${IMAGE_URI}" >> $GITHUB_OUTPUT
+          echo "image_uri=${IMAGE_URI}" >> "$GITHUB_OUTPUT"
           echo "Docker image: ${IMAGE_URI}"
       
       - name: Create EC2 key pair
@@ -162,7 +162,7 @@ jobs:
             --query 'KeyMaterial' \
             --output text > /tmp/eif-builder-key.pem
           chmod 400 /tmp/eif-builder-key.pem
-          echo "key_name=${KEY_NAME}" >> $GITHUB_OUTPUT
+          echo "key_name=${KEY_NAME}" >> "$GITHUB_OUTPUT"
           echo "Created key pair: ${KEY_NAME}"
       
       - name: Get default VPC and subnet
@@ -180,8 +180,8 @@ jobs:
             --query 'Subnets[0].SubnetId' \
             --output text)
           
-          echo "vpc_id=${VPC_ID}" >> $GITHUB_OUTPUT
-          echo "subnet_id=${SUBNET_ID}" >> $GITHUB_OUTPUT
+          echo "vpc_id=${VPC_ID}" >> "$GITHUB_OUTPUT"
+          echo "subnet_id=${SUBNET_ID}" >> "$GITHUB_OUTPUT"
           echo "Using VPC: ${VPC_ID}, Subnet: ${SUBNET_ID} (us-east-1a)"
       
       - name: Create security group
@@ -201,7 +201,7 @@ jobs:
             --port 22 \
             --cidr 0.0.0.0/0
           
-          echo "security_group_id=${SG_ID}" >> $GITHUB_OUTPUT
+          echo "security_group_id=${SG_ID}" >> "$GITHUB_OUTPUT"
           echo "Created security group: ${SG_ID}"
       
       - name: Launch Nitro EC2 instance
@@ -224,7 +224,7 @@ jobs:
             --query 'Instances[0].InstanceId' \
             --output text)
           
-          echo "instance_id=${INSTANCE_ID}" >> $GITHUB_OUTPUT
+          echo "instance_id=${INSTANCE_ID}" >> "$GITHUB_OUTPUT"
           echo "Launched instance: ${INSTANCE_ID}"
           
           echo "Waiting for instance to be running..."
@@ -238,7 +238,7 @@ jobs:
             --query 'Reservations[0].Instances[0].PublicIpAddress' \
             --output text)
           
-          echo "public_ip=${PUBLIC_IP}" >> $GITHUB_OUTPUT
+          echo "public_ip=${PUBLIC_IP}" >> "$GITHUB_OUTPUT"
           echo "Instance ready at: ${PUBLIC_IP}"
       
       - name: Wait for SSH
@@ -301,10 +301,10 @@ jobs:
           PCR2=$(jq -r '.Measurements.PCR2' measurements.json)
           EIF_SHA256=$(sha256sum auction.eif | cut -d' ' -f1)
           
-          echo "pcr0=${PCR0}" >> $GITHUB_OUTPUT
-          echo "pcr1=${PCR1}" >> $GITHUB_OUTPUT
-          echo "pcr2=${PCR2}" >> $GITHUB_OUTPUT
-          echo "eif_sha256=${EIF_SHA256}" >> $GITHUB_OUTPUT
+          echo "pcr0=${PCR0}" >> "$GITHUB_OUTPUT"
+          echo "pcr1=${PCR1}" >> "$GITHUB_OUTPUT"
+          echo "pcr2=${PCR2}" >> "$GITHUB_OUTPUT"
+          echo "eif_sha256=${EIF_SHA256}" >> "$GITHUB_OUTPUT"
       
       - name: Install ORAS
         run: |

--- a/.github/workflows/eif-build.yml
+++ b/.github/workflows/eif-build.yml
@@ -41,10 +41,10 @@ on:
       architecture:
         description: CPU architecture for the Docker image and EIF builder.
         type: choice
-        default: amd64
+        default: arm64
         options:
-          - amd64
           - arm64
+          - amd64
 
 env:
   AWS_REGION: us-east-1
@@ -102,7 +102,9 @@ jobs:
       - name: Resolve builder architecture
         id: builder-arch
         run: |
-          ARCHITECTURE="${{ github.event.inputs.architecture || 'amd64' }}"
+          # arm64 is the default: the automated Docker Build -> Build EIF chain
+          # on main (no input) builds the arm64 EIF. amd64 is opt-in via dispatch.
+          ARCHITECTURE="${{ github.event.inputs.architecture || 'arm64' }}"
           if [ "${ARCHITECTURE}" = "arm64" ]; then
             AMI_ARCH="arm64"
             INSTANCE_TYPE="c7g.xlarge"
@@ -309,6 +311,10 @@ jobs:
       
       - name: Install ORAS
         run: |
+          # This ORAS runs on the GitHub runner (ubuntu-latest = amd64) to push the
+          # already-built EIF artifact to ECR. It is the runner's architecture, not
+          # the target EIF's, so it stays amd64 even for arm64 EIF builds (which are
+          # built on the remote Nitro instance). Do not switch this to arm64.
           VERSION="1.1.0"
           curl -LO "https://github.com/oras-project/oras/releases/download/v${VERSION}/oras_${VERSION}_linux_amd64.tar.gz"
           tar -zxf oras_${VERSION}_*.tar.gz
@@ -354,7 +360,9 @@ jobs:
       - name: Upload artifacts
         uses: actions/upload-artifact@v6
         with:
-          name: eif-${{ steps.set-sha.outputs.commit_short }}
+          # Include the architecture so an amd64 and arm64 build of the same
+          # commit don't collide on the artifact name.
+          name: eif-${{ steps.set-sha.outputs.commit_short }}-${{ steps.builder-arch.outputs.architecture }}
           path: |
             auction.eif
             measurements.json
@@ -416,7 +424,9 @@ jobs:
     name: Update PCR validation file
     runs-on: ubuntu-latest
     needs: build-eif
-    if: github.ref == 'refs/heads/main' && needs.build-eif.outputs.architecture == 'amd64'
+    # arm64 is the canonical fleet, so validation/pcrs.json tracks arm64 PCRs.
+    # amd64 dispatches (now opt-in) don't touch the file to avoid arch-mismatched entries.
+    if: github.ref == 'refs/heads/main' && needs.build-eif.outputs.architecture == 'arm64'
     env:
       GH_APP_ID: '2665276'
 

--- a/.github/workflows/eif-build.yml
+++ b/.github/workflows/eif-build.yml
@@ -38,21 +38,16 @@ on:
         required: true
         default: 'latest'
         type: string
+      architecture:
+        description: CPU architecture for the Docker image and EIF builder.
+        type: choice
+        default: amd64
+        options:
+          - amd64
+          - arm64
 
 env:
   AWS_REGION: us-east-1
-  INSTANCE_TYPE: c5.xlarge
-  # Amazon Linux 2023 AMI
-  # Update periodically to latest AMI
-  #
-  # % aws ec2 describe-images \
-  #  --owners amazon \
-  #  --filters "Name=name,Values=al2023-ami-2023.*-x86_64" \
-  #  --filters "Name=state,Values=available" \
-  #  --query 'sort_by(Images, &CreationDate)[-1].[ImageId,Name,CreationDate]' \
-  #  --output table \
-  #  --region us-east-1
-  AMI_ID: ami-08d7aabbb50c2c24e 
 
 concurrency:
   group: eif-build
@@ -102,6 +97,32 @@ jobs:
           # OIDC role for EIF building workflow (needs EC2 + ECR permissions)
           role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/eif-builder-workflow
           aws-region: ${{ env.AWS_REGION }}
+
+      - name: Resolve builder architecture
+        id: builder-arch
+        run: |
+          ARCHITECTURE="${{ github.event.inputs.architecture || 'amd64' }}"
+          if [ "${ARCHITECTURE}" = "arm64" ]; then
+            AMI_ARCH="arm64"
+            INSTANCE_TYPE="c7g.xlarge"
+          else
+            AMI_ARCH="x86_64"
+            INSTANCE_TYPE="c5.xlarge"
+          fi
+
+          AMI_ID=$(aws ec2 describe-images \
+            --owners amazon \
+            --filters "Name=name,Values=al2023-ami-2023.*-${AMI_ARCH}" \
+                      "Name=state,Values=available" \
+                      "Name=root-device-type,Values=ebs" \
+                      "Name=virtualization-type,Values=hvm" \
+            --query 'sort_by(Images, &CreationDate)[-1].ImageId' \
+            --output text)
+
+          echo "architecture=${ARCHITECTURE}" >> $GITHUB_OUTPUT
+          echo "ami_id=${AMI_ID}" >> $GITHUB_OUTPUT
+          echo "instance_type=${INSTANCE_TYPE}" >> $GITHUB_OUTPUT
+          echo "Using ${ARCHITECTURE} builder ${INSTANCE_TYPE} with AMI ${AMI_ID}"
       
       - name: Construct Docker image URI
         id: image-uri
@@ -181,8 +202,8 @@ jobs:
           # - Access EC2 instance metadata
 
           INSTANCE_ID=$(aws ec2 run-instances \
-            --image-id ${{ env.AMI_ID }} \
-            --instance-type ${{ env.INSTANCE_TYPE }} \
+            --image-id ${{ steps.builder-arch.outputs.ami_id }} \
+            --instance-type ${{ steps.builder-arch.outputs.instance_type }} \
             --key-name "${{ steps.create-key.outputs.key_name }}" \
             --security-group-ids "${{ steps.security-group.outputs.security_group_id }}" \
             --subnet-id "${{ steps.vpc-info.outputs.subnet_id }}" \

--- a/.github/workflows/eif-build.yml
+++ b/.github/workflows/eif-build.yml
@@ -313,10 +313,17 @@ jobs:
         run: |
           COMMIT_SHA="${{ steps.set-sha.outputs.commit_sha }}"
           COMMIT_SHORT="${{ steps.set-sha.outputs.commit_short }}"
+          ARCHITECTURE="${{ steps.builder-arch.outputs.architecture }}"
           REGISTRY="${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${{ env.AWS_REGION }}.amazonaws.com"
           REPO="cloudx-io/openauction/enclave-eif"
+
+          if [ "${ARCHITECTURE}" = "arm64" ]; then
+            TAG_SUFFIX="-arm64"
+          else
+            TAG_SUFFIX=""
+          fi
           
-          oras push "${REGISTRY}/${REPO}:${COMMIT_SHA}" \
+          oras push "${REGISTRY}/${REPO}:${COMMIT_SHA}${TAG_SUFFIX}" \
             --artifact-type application/vnd.aws.nitro.eif \
             --annotation "org.opencontainers.image.created=$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
             --annotation "org.opencontainers.image.revision=${COMMIT_SHA}" \
@@ -326,11 +333,11 @@ jobs:
             auction.eif:application/octet-stream \
             measurements.json:application/json
           
-          if [ "${{ github.ref }}" = "refs/heads/main" ]; then
-            oras tag "${REGISTRY}/${REPO}:${COMMIT_SHA}" latest
+          if [ "${{ github.ref }}" = "refs/heads/main" ] && [ -z "${TAG_SUFFIX}" ]; then
+            oras tag "${REGISTRY}/${REPO}:${COMMIT_SHA}${TAG_SUFFIX}" latest
           fi
           
-          oras tag "${REGISTRY}/${REPO}:${COMMIT_SHA}" "${COMMIT_SHORT}"
+          oras tag "${REGISTRY}/${REPO}:${COMMIT_SHA}${TAG_SUFFIX}" "${COMMIT_SHORT}${TAG_SUFFIX}"
       
       - name: Upload artifacts
         uses: actions/upload-artifact@v6

--- a/.github/workflows/eif-build.yml
+++ b/.github/workflows/eif-build.yml
@@ -34,9 +34,9 @@ on:
   workflow_dispatch:
     inputs:
       image_tag:
-        description: 'Docker image tag to use (e.g., sha-abc1234, latest). Image must exist in ECR.'
-        required: true
-        default: 'latest'
+        description: 'Optional Docker image tag to use. Leave blank to use the checked-out commit SHA.'
+        required: false
+        default: ''
         type: string
       architecture:
         description: CPU architecture for the Docker image and EIF builder.

--- a/.github/workflows/eif-build.yml
+++ b/.github/workflows/eif-build.yml
@@ -143,6 +143,12 @@ jobs:
             echo "Using commit-based image tag: ${IMAGE_TAG}"
           fi
 
+          ARCHITECTURE="${{ steps.builder-arch.outputs.architecture }}"
+          if [ "${ARCHITECTURE}" = "arm64" ] && [[ "${IMAGE_TAG}" != *-arm64 ]]; then
+            IMAGE_TAG="${IMAGE_TAG}-arm64"
+            echo "Using arm64 image tag: ${IMAGE_TAG}"
+          fi
+
           IMAGE_URI="${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${{ env.AWS_REGION }}.amazonaws.com/cloudx-io/openauction/enclave:${IMAGE_TAG}"
           echo "image_uri=${IMAGE_URI}" >> $GITHUB_OUTPUT
           echo "Docker image: ${IMAGE_URI}"


### PR DESCRIPTION
## Context

Makes **arm64 the default architecture** for the enclave Docker image and EIF
build pipelines, as the first artifact-side step of migrating the TEE fleet to
Graviton.

- The automated `Go → Docker Build → Build EIF` chain on `main` now builds
  **arm64** (image, EIF, and `latest-arm64`). **amd64** becomes an opt-in
  `workflow_dispatch` choice for both workflows.
- The `-arm64` tag-suffix scheme is preserved: arm64 = `<sha>-arm64`, amd64 =
  bare `<sha>`. This is deliberate — the TEE rollout pins the Graviton canary to
  `<sha>-arm64` while the x86 primary still uses the bare `<sha>`, so both tags
  must coexist during canary → cutover.
- `validation/pcrs.json` now tracks **arm64** PCRs (the canonical fleet); amd64
  dispatches no longer append to it (PCRs are architecture-specific).
- EIF is built on a `c7g.xlarge` with a runtime-resolved AL2023 arm64 AMI
  (replaces the previously pinned x86 AMI); QEMU is set up for the arm64 Docker
  build.
- The EIF `upload-artifact` name is suffixed with the architecture so an amd64
  and arm64 build of the same commit don't collide.
