### PR TITLE
enclave: report attestation call latency in responses

### DIFF
--- a/enclave/auction.go
+++ b/enclave/auction.go
@@ -56,7 +56,7 @@ func ProcessAuction(attester EnclaveAttester, req enclaveapi.EnclaveAuctionReque
 	winner := auctionResult.Winner
 	runnerUp := auctionResult.RunnerUp
 
-	coseAttestation, err := GenerateTEEProofs(attester, req, unencryptedBids, winner, runnerUp)
+	coseAttestation, attestationUs, err := GenerateTEEProofs(attester, req, unencryptedBids, winner, runnerUp)
 	processingTime := time.Since(startTime).Milliseconds()
 
 	log.Printf("INFO: Auction complete: winner=%s (%.2f), runner-up=%s (%.2f), processing=%dms",
@@ -82,6 +82,7 @@ func ProcessAuction(attester EnclaveAttester, req enclaveapi.EnclaveAuctionReque
 		ExcludedBids:          excludedBids,
 		FloorRejectedBidIDs:   floorRejectedBidIDs,
 		ProcessingTime:        processingTime,
+		AttestationUs:         &attestationUs,
 	}
 }
 

--- a/enclave/auction.go
+++ b/enclave/auction.go
@@ -82,7 +82,7 @@ func ProcessAuction(attester EnclaveAttester, req enclaveapi.EnclaveAuctionReque
 		ExcludedBids:          excludedBids,
 		FloorRejectedBidIDs:   floorRejectedBidIDs,
 		ProcessingTime:        processingTime,
-		AttestationUs:         &attestationUs,
+		AttestationUs:         attestationUs,
 	}
 }
 

--- a/enclave/keymanager.go
+++ b/enclave/keymanager.go
@@ -72,6 +72,6 @@ func HandleKeyRequest(attester EnclaveAttester, keyManager *KeyManager, tokenMan
 			AuctionToken: auctionToken,
 		},
 		Type:          "key_response",
-		AttestationUs: &attestationUs,
+		AttestationUs: attestationUs,
 	}, nil
 }

--- a/enclave/keymanager.go
+++ b/enclave/keymanager.go
@@ -55,7 +55,7 @@ func HandleKeyRequest(attester EnclaveAttester, keyManager *KeyManager, tokenMan
 
 	auctionToken := tokenManager.GenerateToken()
 
-	coseAttestation, err := GenerateKeyAttestation(attester, keyManager.PublicKey, auctionToken)
+	coseAttestation, attestationUs, err := GenerateKeyAttestation(attester, keyManager.PublicKey, auctionToken)
 	if err != nil {
 		return nil, fmt.Errorf("failed to generate key attestation: %w", err)
 	}
@@ -71,6 +71,7 @@ func HandleKeyRequest(attester EnclaveAttester, keyManager *KeyManager, tokenMan
 			Attestation:  attestationGzip,
 			AuctionToken: auctionToken,
 		},
-		Type: "key_response",
+		Type:          "key_response",
+		AttestationUs: &attestationUs,
 	}, nil
 }

--- a/enclave/proofs.go
+++ b/enclave/proofs.go
@@ -22,20 +22,20 @@ type EnclaveAttester interface {
 	Attest(options enclave.AttestationOptions) ([]byte, error)
 }
 
-func GenerateTEEProofs(attester EnclaveAttester, req enclaveapi.EnclaveAuctionRequest, unencryptedBids []core.CoreBid, winner, runnerUp *core.CoreBid) (enclaveapi.AttestationCOSE, float64, error) {
+func GenerateTEEProofs(attester EnclaveAttester, req enclaveapi.EnclaveAuctionRequest, unencryptedBids []core.CoreBid, winner, runnerUp *core.CoreBid) (enclaveapi.AttestationCOSE, *float64, error) {
 	bidHashNonce, err := generateNonce()
 	if err != nil {
-		return nil, 0, fmt.Errorf("failed to generate bid hash nonce: %w", err)
+		return nil, nil, fmt.Errorf("failed to generate bid hash nonce: %w", err)
 	}
 
 	requestNonce, err := generateNonce()
 	if err != nil {
-		return nil, 0, fmt.Errorf("failed to generate request nonce: %w", err)
+		return nil, nil, fmt.Errorf("failed to generate request nonce: %w", err)
 	}
 
 	adjustmentFactorsNonce, err := generateNonce()
 	if err != nil {
-		return nil, 0, fmt.Errorf("failed to generate adjustment factors nonce: %w", err)
+		return nil, nil, fmt.Errorf("failed to generate adjustment factors nonce: %w", err)
 	}
 
 	// Build list of bid hashes from decrypted bids
@@ -111,7 +111,7 @@ func GenerateAttestation(
 	adjustmentFactorsNonce string,
 	winner *core.CoreBid,
 	runnerUp *core.CoreBid,
-) (enclaveapi.AttestationCOSE, float64, error) {
+) (enclaveapi.AttestationCOSE, *float64, error) {
 	now := time.Now()
 
 	// Create the user data that will be embedded in the attestation
@@ -132,17 +132,17 @@ func GenerateAttestation(
 	}
 
 	if attester == nil {
-		return nil, 0, fmt.Errorf("enclave attester is nil")
+		return nil, nil, fmt.Errorf("enclave attester is nil")
 	}
 
 	// Marshal user data for the real attestation
 	userDataBytes, err := json.Marshal(userData)
 	if err != nil {
-		return nil, 0, fmt.Errorf("failed to marshal user data: %w", err)
+		return nil, nil, fmt.Errorf("failed to marshal user data: %w", err)
 	}
 	randomNonce, err := generateNonce()
 	if err != nil {
-		return nil, 0, fmt.Errorf("failed to generate attestation nonce: %w", err)
+		return nil, nil, fmt.Errorf("failed to generate attestation nonce: %w", err)
 	}
 
 	attestStart := time.Now()
@@ -150,15 +150,15 @@ func GenerateAttestation(
 		UserData: userDataBytes,
 		Nonce:    []byte(randomNonce),
 	})
-	attestationUs := float64(time.Since(attestStart).Nanoseconds()) / 1000.0
 	if err != nil {
 		log.Printf("ERROR: NSM attestation failed: %v", err)
-		return nil, 0, fmt.Errorf("NSM attestation failed: %w", err)
+		return nil, nil, fmt.Errorf("NSM attestation failed: %w", err)
 	}
+	attestationUs := float64(time.Since(attestStart).Nanoseconds()) / 1000.0
 
 	log.Printf("INFO: Real NSM attestation generated: %d bytes", len(attestationCBOR))
 
-	return enclaveapi.AttestationCOSE(attestationCBOR), attestationUs, nil
+	return enclaveapi.AttestationCOSE(attestationCBOR), &attestationUs, nil
 }
 
 // publicKeyToPEM converts an RSA public key to PEM format
@@ -177,15 +177,15 @@ func publicKeyToPEM(publicKey *rsa.PublicKey) (string, error) {
 }
 
 // GenerateKeyAttestation generates raw COSE bytes for E2EE public keys
-func GenerateKeyAttestation(attester EnclaveAttester, publicKey *rsa.PublicKey, auctionToken string) (enclaveapi.AttestationCOSE, float64, error) {
+func GenerateKeyAttestation(attester EnclaveAttester, publicKey *rsa.PublicKey, auctionToken string) (enclaveapi.AttestationCOSE, *float64, error) {
 	if attester == nil {
-		return nil, 0, fmt.Errorf("enclave attester is nil")
+		return nil, nil, fmt.Errorf("enclave attester is nil")
 	}
 
 	// Convert public key to PEM format for inclusion in attestation
 	publicKeyPEM, err := publicKeyToPEM(publicKey)
 	if err != nil {
-		return nil, 0, fmt.Errorf("failed to convert public key to PEM: %w", err)
+		return nil, nil, fmt.Errorf("failed to convert public key to PEM: %w", err)
 	}
 
 	keyUserData := &enclaveapi.KeyAttestationUserData{
@@ -196,12 +196,12 @@ func GenerateKeyAttestation(attester EnclaveAttester, publicKey *rsa.PublicKey, 
 
 	userDataBytes, err := json.Marshal(keyUserData)
 	if err != nil {
-		return nil, 0, fmt.Errorf("failed to marshal key user data: %w", err)
+		return nil, nil, fmt.Errorf("failed to marshal key user data: %w", err)
 	}
 
 	randomNonce, err := generateNonce()
 	if err != nil {
-		return nil, 0, fmt.Errorf("failed to generate attestation nonce: %w", err)
+		return nil, nil, fmt.Errorf("failed to generate attestation nonce: %w", err)
 	}
 
 	attestStart := time.Now()
@@ -209,13 +209,13 @@ func GenerateKeyAttestation(attester EnclaveAttester, publicKey *rsa.PublicKey, 
 		UserData: userDataBytes,
 		Nonce:    []byte(randomNonce),
 	})
-	attestationUs := float64(time.Since(attestStart).Nanoseconds()) / 1000.0
 	if err != nil {
 		log.Printf("ERROR: NSM key attestation failed: %v", err)
-		return nil, 0, fmt.Errorf("NSM key attestation failed: %w", err)
+		return nil, nil, fmt.Errorf("NSM key attestation failed: %w", err)
 	}
+	attestationUs := float64(time.Since(attestStart).Nanoseconds()) / 1000.0
 
 	log.Printf("Key attestation generated: %d bytes", len(attestationCBOR))
 
-	return enclaveapi.AttestationCOSE(attestationCBOR), attestationUs, nil
+	return enclaveapi.AttestationCOSE(attestationCBOR), &attestationUs, nil
 }

--- a/enclave/proofs.go
+++ b/enclave/proofs.go
@@ -22,20 +22,20 @@ type EnclaveAttester interface {
 	Attest(options enclave.AttestationOptions) ([]byte, error)
 }
 
-func GenerateTEEProofs(attester EnclaveAttester, req enclaveapi.EnclaveAuctionRequest, unencryptedBids []core.CoreBid, winner, runnerUp *core.CoreBid) (enclaveapi.AttestationCOSE, error) {
+func GenerateTEEProofs(attester EnclaveAttester, req enclaveapi.EnclaveAuctionRequest, unencryptedBids []core.CoreBid, winner, runnerUp *core.CoreBid) (enclaveapi.AttestationCOSE, float64, error) {
 	bidHashNonce, err := generateNonce()
 	if err != nil {
-		return nil, fmt.Errorf("failed to generate bid hash nonce: %w", err)
+		return nil, 0, fmt.Errorf("failed to generate bid hash nonce: %w", err)
 	}
 
 	requestNonce, err := generateNonce()
 	if err != nil {
-		return nil, fmt.Errorf("failed to generate request nonce: %w", err)
+		return nil, 0, fmt.Errorf("failed to generate request nonce: %w", err)
 	}
 
 	adjustmentFactorsNonce, err := generateNonce()
 	if err != nil {
-		return nil, fmt.Errorf("failed to generate adjustment factors nonce: %w", err)
+		return nil, 0, fmt.Errorf("failed to generate adjustment factors nonce: %w", err)
 	}
 
 	// Build list of bid hashes from decrypted bids
@@ -111,7 +111,7 @@ func GenerateAttestation(
 	adjustmentFactorsNonce string,
 	winner *core.CoreBid,
 	runnerUp *core.CoreBid,
-) (enclaveapi.AttestationCOSE, error) {
+) (enclaveapi.AttestationCOSE, float64, error) {
 	now := time.Now()
 
 	// Create the user data that will be embedded in the attestation
@@ -132,31 +132,33 @@ func GenerateAttestation(
 	}
 
 	if attester == nil {
-		return nil, fmt.Errorf("enclave attester is nil")
+		return nil, 0, fmt.Errorf("enclave attester is nil")
 	}
 
 	// Marshal user data for the real attestation
 	userDataBytes, err := json.Marshal(userData)
 	if err != nil {
-		return nil, fmt.Errorf("failed to marshal user data: %w", err)
+		return nil, 0, fmt.Errorf("failed to marshal user data: %w", err)
 	}
 	randomNonce, err := generateNonce()
 	if err != nil {
-		return nil, fmt.Errorf("failed to generate attestation nonce: %w", err)
+		return nil, 0, fmt.Errorf("failed to generate attestation nonce: %w", err)
 	}
 
+	attestStart := time.Now()
 	attestationCBOR, err := attester.Attest(enclave.AttestationOptions{
 		UserData: userDataBytes,
 		Nonce:    []byte(randomNonce),
 	})
+	attestationUs := float64(time.Since(attestStart).Nanoseconds()) / 1000.0
 	if err != nil {
 		log.Printf("ERROR: NSM attestation failed: %v", err)
-		return nil, fmt.Errorf("NSM attestation failed: %w", err)
+		return nil, 0, fmt.Errorf("NSM attestation failed: %w", err)
 	}
 
 	log.Printf("INFO: Real NSM attestation generated: %d bytes", len(attestationCBOR))
 
-	return enclaveapi.AttestationCOSE(attestationCBOR), nil
+	return enclaveapi.AttestationCOSE(attestationCBOR), attestationUs, nil
 }
 
 // publicKeyToPEM converts an RSA public key to PEM format
@@ -175,15 +177,15 @@ func publicKeyToPEM(publicKey *rsa.PublicKey) (string, error) {
 }
 
 // GenerateKeyAttestation generates raw COSE bytes for E2EE public keys
-func GenerateKeyAttestation(attester EnclaveAttester, publicKey *rsa.PublicKey, auctionToken string) (enclaveapi.AttestationCOSE, error) {
+func GenerateKeyAttestation(attester EnclaveAttester, publicKey *rsa.PublicKey, auctionToken string) (enclaveapi.AttestationCOSE, float64, error) {
 	if attester == nil {
-		return nil, fmt.Errorf("enclave attester is nil")
+		return nil, 0, fmt.Errorf("enclave attester is nil")
 	}
 
 	// Convert public key to PEM format for inclusion in attestation
 	publicKeyPEM, err := publicKeyToPEM(publicKey)
 	if err != nil {
-		return nil, fmt.Errorf("failed to convert public key to PEM: %w", err)
+		return nil, 0, fmt.Errorf("failed to convert public key to PEM: %w", err)
 	}
 
 	keyUserData := &enclaveapi.KeyAttestationUserData{
@@ -194,24 +196,26 @@ func GenerateKeyAttestation(attester EnclaveAttester, publicKey *rsa.PublicKey, 
 
 	userDataBytes, err := json.Marshal(keyUserData)
 	if err != nil {
-		return nil, fmt.Errorf("failed to marshal key user data: %w", err)
+		return nil, 0, fmt.Errorf("failed to marshal key user data: %w", err)
 	}
 
 	randomNonce, err := generateNonce()
 	if err != nil {
-		return nil, fmt.Errorf("failed to generate attestation nonce: %w", err)
+		return nil, 0, fmt.Errorf("failed to generate attestation nonce: %w", err)
 	}
 
+	attestStart := time.Now()
 	attestationCBOR, err := attester.Attest(enclave.AttestationOptions{
 		UserData: userDataBytes,
 		Nonce:    []byte(randomNonce),
 	})
+	attestationUs := float64(time.Since(attestStart).Nanoseconds()) / 1000.0
 	if err != nil {
 		log.Printf("ERROR: NSM key attestation failed: %v", err)
-		return nil, fmt.Errorf("NSM key attestation failed: %w", err)
+		return nil, 0, fmt.Errorf("NSM key attestation failed: %w", err)
 	}
 
 	log.Printf("Key attestation generated: %d bytes", len(attestationCBOR))
 
-	return enclaveapi.AttestationCOSE(attestationCBOR), nil
+	return enclaveapi.AttestationCOSE(attestationCBOR), attestationUs, nil
 }

--- a/enclave/proofs_test.go
+++ b/enclave/proofs_test.go
@@ -113,7 +113,7 @@ func TestGenerateAttestation(t *testing.T) {
 
 	// Test with nil enclave handle (error case)
 	bidHashes := []string{"hash1", "hash2"}
-	coseBytes, err := GenerateAttestation(nil, req, bidHashes, "test_request_hash", "test_adj_hash",
+	coseBytes, _, err := GenerateAttestation(nil, req, bidHashes, "test_request_hash", "test_adj_hash",
 		"test_bid_nonce", "test_req_nonce", "test_adj_nonce", winner, runnerUp)
 
 	// Should fail with nil enclave handle
@@ -143,13 +143,15 @@ func TestGenerateAttestationWithMock(t *testing.T) {
 	bidHash := core.ComputeBidHash("bid1", 2.50, bidHashNonce)
 
 	// Test successful attestation generation with mock
-	coseBytes, err := GenerateAttestation(mockEnclave, req, []string{bidHash}, "test_request_hash", "test_adj_hash",
+	coseBytes, attestationUs, err := GenerateAttestation(mockEnclave, req, []string{bidHash}, "test_request_hash", "test_adj_hash",
 		bidHashNonce, "test_req_nonce", "test_adj_nonce", winner, nil)
 
 	// Should succeed with mock enclave
 	check.NoError(t, err)
 	check.NotNil(t, coseBytes)
 	check.True(t, len(coseBytes) > 0)
+	// Attestation timing is measured and reported in microseconds.
+	check.True(t, attestationUs >= 0)
 
 	attestationDoc := parseAuctionAttestationFromCOSE(t, coseBytes)
 	check.Equal(t, "test-enclave-12345", attestationDoc.ModuleID)
@@ -219,13 +221,14 @@ func TestGenerateAttestationWithEncryptedBids(t *testing.T) {
 	bidHashes := []string{hash2, hash3}
 
 	// Test successful attestation generation with encrypted bids
-	coseBytes, err := GenerateAttestation(mockEnclave, req, bidHashes, "test_request_hash", "test_adj_hash",
+	coseBytes, attestationUs, err := GenerateAttestation(mockEnclave, req, bidHashes, "test_request_hash", "test_adj_hash",
 		bidHashNonce, "test_req_nonce", "test_adj_nonce", winner, runnerUp)
 
 	// Should succeed with mock enclave
 	check.NoError(t, err)
 	check.NotNil(t, coseBytes)
 	check.True(t, len(coseBytes) > 0)
+	check.True(t, attestationUs >= 0)
 
 	attestationDoc := parseAuctionAttestationFromCOSE(t, coseBytes)
 	check.Equal(t, "test-enclave-12345", attestationDoc.ModuleID)
@@ -267,7 +270,7 @@ func TestGenerateKeyAttestation(t *testing.T) {
 	check.NoError(t, err)
 
 	testToken := "550e8400-e29b-41d4-a716-446655440000"
-	coseBytes, err := GenerateKeyAttestation(nil, &privateKey.PublicKey, testToken)
+	coseBytes, _, err := GenerateKeyAttestation(nil, &privateKey.PublicKey, testToken)
 
 	// Should fail with nil enclave handle
 	check.Error(t, err)
@@ -287,12 +290,13 @@ func TestGenerateKeyAttestationWithMock(t *testing.T) {
 	testToken := "550e8400-e29b-41d4-a716-446655440000"
 
 	// Test successful key attestation generation with mock
-	coseBytes, err := GenerateKeyAttestation(mockEnclave, &privateKey.PublicKey, testToken)
+	coseBytes, attestationUs, err := GenerateKeyAttestation(mockEnclave, &privateKey.PublicKey, testToken)
 
 	// Should succeed with mock enclave
 	check.NoError(t, err)
 	check.NotNil(t, coseBytes)
 	check.True(t, len(coseBytes) > 0)
+	check.True(t, attestationUs >= 0)
 
 	// Verify COSE bytes can be parsed
 	attestationDoc, userData, err := enclaveapi.AttestationCOSE(coseBytes).ParseAttestationDoc()
@@ -495,7 +499,7 @@ func TestGenerateAttestationWithMixedBidTypes(t *testing.T) {
 	bidHashes := []string{hashU1, hashE1, hashU2, hashE2, hashU3}
 
 	// Generate attestation for mixed bid scenario
-	coseBytes, err := GenerateAttestation(mockEnclave, req, bidHashes, "mixed_request_hash", "mixed_adj_hash",
+	coseBytes, _, err := GenerateAttestation(mockEnclave, req, bidHashes, "mixed_request_hash", "mixed_adj_hash",
 		bidHashNonce, "mixed_req_nonce", "mixed_adj_nonce", winner, runnerUp)
 
 	// Verify successful attestation generation

--- a/enclave/proofs_test.go
+++ b/enclave/proofs_test.go
@@ -150,8 +150,9 @@ func TestGenerateAttestationWithMock(t *testing.T) {
 	check.NoError(t, err)
 	check.NotNil(t, coseBytes)
 	check.True(t, len(coseBytes) > 0)
-	// Attestation timing is measured and reported in microseconds.
-	check.True(t, attestationUs >= 0)
+	// Attestation timing is measured (non-nil) and reported in microseconds.
+	check.NotNil(t, attestationUs)
+	check.True(t, *attestationUs > 0)
 
 	attestationDoc := parseAuctionAttestationFromCOSE(t, coseBytes)
 	check.Equal(t, "test-enclave-12345", attestationDoc.ModuleID)
@@ -228,7 +229,8 @@ func TestGenerateAttestationWithEncryptedBids(t *testing.T) {
 	check.NoError(t, err)
 	check.NotNil(t, coseBytes)
 	check.True(t, len(coseBytes) > 0)
-	check.True(t, attestationUs >= 0)
+	check.NotNil(t, attestationUs)
+	check.True(t, *attestationUs > 0)
 
 	attestationDoc := parseAuctionAttestationFromCOSE(t, coseBytes)
 	check.Equal(t, "test-enclave-12345", attestationDoc.ModuleID)
@@ -296,7 +298,8 @@ func TestGenerateKeyAttestationWithMock(t *testing.T) {
 	check.NoError(t, err)
 	check.NotNil(t, coseBytes)
 	check.True(t, len(coseBytes) > 0)
-	check.True(t, attestationUs >= 0)
+	check.NotNil(t, attestationUs)
+	check.True(t, *attestationUs > 0)
 
 	// Verify COSE bytes can be parsed
 	attestationDoc, userData, err := enclaveapi.AttestationCOSE(coseBytes).ParseAttestationDoc()

--- a/enclaveapi/types.go
+++ b/enclaveapi/types.go
@@ -156,12 +156,23 @@ type EnclaveAuctionResponse struct {
 	ExcludedBids          []core.ExcludedBid    `json:"excluded_bids,omitempty"`           // Decryption failures, validation errors
 	FloorRejectedBidIDs   []string              `json:"floor_rejected_bid_ids,omitempty"`  // Bid IDs that were below floor
 	ProcessingTime        int64                 `json:"processing_time_ms"`
+	// AttestationUs is the wall-clock time spent in the attestation call, in
+	// microseconds. Reported in us (not ms) because the value is often
+	// sub-millisecond and integer-ms rounding would hide it. A pointer so that
+	// "not measured" (attestation failed or was not reached) is nil rather than
+	// an ambiguous 0. Operational timing only; not part of the attested payload.
+	AttestationUs *float64 `json:"attestation_us,omitempty"`
 }
 
 // KeyResponse represents the response from a key request to the TEE enclave
 type KeyResponse struct {
 	KeyWithAttestation
 	Type string `json:"type"`
+	// AttestationUs is the wall-clock time spent in the attestation call, in
+	// microseconds (see EnclaveAuctionResponse.AttestationUs). Pointer so "not
+	// measured" is nil rather than an ambiguous 0. Operational timing only; not
+	// part of the attested payload.
+	AttestationUs *float64 `json:"attestation_us,omitempty"`
 }
 
 // KeyWithAttestation represents a public key with its TEE attestation


### PR DESCRIPTION
## Summary

- Measure the wall-clock time spent in the attestation call (`Attest()`) and include it as `attestation_us` (microseconds) on the auction and key response wrappers.
- The field is a `*float64` so "not measured" (attestation failed or was not reached) is `nil`, not an ambiguous `0`, following the existing convention for optional response fields.
- The value lives on the response wrapper, outside the attested `userData`, so it does not change the attestation document or PCRs.

## Why microseconds

The attestation call is frequently sub-millisecond, so integer-millisecond timing would round the signal away. Microseconds preserve the low-end resolution while staying well within the value's real precision.

## Test plan

- [x] `go build ./...`
- [x] `go test ./enclave/... ./enclaveapi/...`
- [x] `go vet ./enclave/... ./enclaveapi/...`

Made with [Cursor](https://cursor.com)