### PR TITLE
Adopt mise for toolchain + tasks, pin GitHub Actions with ratchet

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -21,10 +21,10 @@ jobs:
       id-token: write # for AWS OIDC authentication
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # ratchet:actions/checkout@v7
         with:
           ref: ${{ github.event.workflow_run.head_sha || github.sha }}
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # ratchet:actions/setup-go@v6
         with:
           go-version: "1.25.1"
       - name: docker set architecture env vars
@@ -50,13 +50,13 @@ jobs:
           echo "PUBLISH_IMAGE=${PUBLISH_IMAGE}" >> "$GITHUB_ENV"
       - name: Configure AWS credentials
         if: env.PUBLISH_IMAGE == 'true'
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@517a711dbcd0e402f90c77e7e2f81e849156e31d # ratchet:aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/github-actions-ecr-push
           aws-region: us-east-1
       - name: Login to Amazon ECR
         if: env.PUBLISH_IMAGE == 'true'
-        uses: aws-actions/amazon-ecr-login@v2
+        uses: aws-actions/amazon-ecr-login@d539f0932e70871a027e9d5a9d8fc38589180a64 # ratchet:aws-actions/amazon-ecr-login@v2
       - name: go build enclave binary
         run: |
           CGO_ENABLED=0 GOOS=linux GOARCH=${{ env.ARCHITECTURE }} go build -a -ldflags '-extldflags "-static"' -tags netgo -o ./bin/tee-auction-enclave ./enclave
@@ -71,7 +71,7 @@ jobs:
       - name: docker set metadata
         id: dockermetadata
         # https://github.com/docker/metadata-action
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # ratchet:docker/metadata-action@v6
         with:
           images: |
             ${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.us-east-1.amazonaws.com/cloudx-io/openauction/enclave
@@ -89,12 +89,12 @@ jobs:
             type=raw,value=${{ env.CLOUDX_VERSION }}-commit.${{ env.CLOUDX_COMMIT }}${{ env.IMAGE_TAG_SUFFIX }}
             # "latest"
             type=raw,value=latest${{ env.IMAGE_TAG_SUFFIX }},enable=${{ github.event.workflow_run.head_branch == 'main' || github.ref == 'refs/heads/main' }}
-      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # ratchet:docker/setup-qemu-action@v4
         if: env.ARCHITECTURE == 'arm64'
-      - uses: docker/setup-buildx-action@v4
+      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # ratchet:docker/setup-buildx-action@v4
         with:
           platforms: linux/${{ env.ARCHITECTURE }}
-      - uses: docker/build-push-action@v7
+      - uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # ratchet:docker/build-push-action@v7
         with:
           context: .
           file: enclave/Dockerfile

--- a/.github/workflows/eif-build.yml
+++ b/.github/workflows/eif-build.yml
@@ -65,7 +65,7 @@ jobs:
     permissions:
       id-token: write
       contents: read
-    
+
     outputs:
       architecture: ${{ steps.builder-arch.outputs.architecture }}
       pcr0: ${{ steps.extract-pcrs.outputs.pcr0 }}
@@ -73,13 +73,13 @@ jobs:
       pcr2: ${{ steps.extract-pcrs.outputs.pcr2 }}
       eif_sha256: ${{ steps.extract-pcrs.outputs.eif_sha256 }}
       commit_sha: ${{ steps.set-sha.outputs.commit_sha }}
-    
+
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # ratchet:actions/checkout@v7
         with:
           ref: ${{ github.event.workflow_run.head_sha || github.sha }}
-      
+
       - name: Set commit SHA variable
         id: set-sha
         run: |
@@ -91,9 +91,9 @@ jobs:
           echo "commit_sha=${COMMIT_SHA}" >> "$GITHUB_OUTPUT"
           echo "commit_short=${COMMIT_SHA:0:7}" >> "$GITHUB_OUTPUT"
           echo "Building EIF for commit: ${COMMIT_SHA}"
-      
+
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@517a711dbcd0e402f90c77e7e2f81e849156e31d # ratchet:aws-actions/configure-aws-credentials@v6
         with:
           # OIDC role for EIF building workflow (needs EC2 + ECR permissions)
           role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/eif-builder-workflow
@@ -131,7 +131,7 @@ jobs:
           echo "ami_id=${AMI_ID}" >> "$GITHUB_OUTPUT"
           echo "instance_type=${INSTANCE_TYPE}" >> "$GITHUB_OUTPUT"
           echo "Using ${ARCHITECTURE} builder ${INSTANCE_TYPE} with AMI ${AMI_ID}"
-      
+
       - name: Construct Docker image URI
         id: image-uri
         run: |
@@ -155,7 +155,7 @@ jobs:
           IMAGE_URI="${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${{ env.AWS_REGION }}.amazonaws.com/cloudx-io/openauction/enclave:${IMAGE_TAG}"
           echo "image_uri=${IMAGE_URI}" >> "$GITHUB_OUTPUT"
           echo "Docker image: ${IMAGE_URI}"
-      
+
       - name: Create EC2 key pair
         id: create-key
         run: |
@@ -167,7 +167,7 @@ jobs:
           chmod 400 /tmp/eif-builder-key.pem
           echo "key_name=${KEY_NAME}" >> "$GITHUB_OUTPUT"
           echo "Created key pair: ${KEY_NAME}"
-      
+
       - name: Get default VPC and subnet
         id: vpc-info
         run: |
@@ -175,18 +175,18 @@ jobs:
             --filters "Name=isDefault,Values=true" \
             --query 'Vpcs[0].VpcId' \
             --output text)
-          
+
           # Use us-east-1a for consistent instance type availability
           SUBNET_ID=$(aws ec2 describe-subnets \
             --filters "Name=vpc-id,Values=${VPC_ID}" \
                       "Name=availability-zone,Values=us-east-1a" \
             --query 'Subnets[0].SubnetId' \
             --output text)
-          
+
           echo "vpc_id=${VPC_ID}" >> "$GITHUB_OUTPUT"
           echo "subnet_id=${SUBNET_ID}" >> "$GITHUB_OUTPUT"
           echo "Using VPC: ${VPC_ID}, Subnet: ${SUBNET_ID} (us-east-1a)"
-      
+
       - name: Create security group
         id: security-group
         run: |
@@ -197,16 +197,16 @@ jobs:
             --vpc-id "${{ steps.vpc-info.outputs.vpc_id }}" \
             --query 'GroupId' \
             --output text)
-          
+
           aws ec2 authorize-security-group-ingress \
             --group-id "${SG_ID}" \
             --protocol tcp \
             --port 22 \
             --cidr 0.0.0.0/0
-          
+
           echo "security_group_id=${SG_ID}" >> "$GITHUB_OUTPUT"
           echo "Created security group: ${SG_ID}"
-      
+
       - name: Launch Nitro EC2 instance
         id: launch-instance
         run: |
@@ -226,24 +226,24 @@ jobs:
             --iam-instance-profile Name=eif-builder-instance \
             --query 'Instances[0].InstanceId' \
             --output text)
-          
+
           echo "instance_id=${INSTANCE_ID}" >> "$GITHUB_OUTPUT"
           echo "Launched instance: ${INSTANCE_ID}"
-          
+
           echo "Waiting for instance to be running..."
           aws ec2 wait instance-running --instance-ids "${INSTANCE_ID}"
 
           echo "Waiting for status checks..."
           aws ec2 wait instance-status-ok --instance-ids "${INSTANCE_ID}"
-          
+
           PUBLIC_IP=$(aws ec2 describe-instances \
             --instance-ids "${INSTANCE_ID}" \
             --query 'Reservations[0].Instances[0].PublicIpAddress' \
             --output text)
-          
+
           echo "public_ip=${PUBLIC_IP}" >> "$GITHUB_OUTPUT"
           echo "Instance ready at: ${PUBLIC_IP}"
-      
+
       - name: Wait for SSH
         run: |
           echo "Waiting for SSH..."
@@ -259,21 +259,21 @@ jobs:
             echo "Attempt $i/30, waiting 10s..."
             sleep 10
           done
-      
+
       - name: Copy scripts to instance
         run: |
           scp -i /tmp/eif-builder-key.pem \
               -o StrictHostKeyChecking=no \
               -r enclave/scripts \
               ec2-user@${{ steps.launch-instance.outputs.public_ip }}:~/
-      
+
       - name: Setup Nitro instance
         run: |
           ssh -i /tmp/eif-builder-key.pem \
               -o StrictHostKeyChecking=no \
               ec2-user@${{ steps.launch-instance.outputs.public_ip }} \
               'sudo bash ~/scripts/setup-nitro-instance.sh'
-      
+
       - name: Build EIF
         run: |
           ssh -i /tmp/eif-builder-key.pem \
@@ -283,19 +283,19 @@ jobs:
                     '${{ steps.image-uri.outputs.image_uri }}' \
                     '/tmp/auction.eif' \
                     '${{ env.AWS_REGION }}'"
-      
+
       - name: Download EIF and measurements
         run: |
           scp -i /tmp/eif-builder-key.pem \
               -o StrictHostKeyChecking=no \
               ec2-user@${{ steps.launch-instance.outputs.public_ip }}:/tmp/auction.eif \
               ./auction.eif
-          
+
           scp -i /tmp/eif-builder-key.pem \
               -o StrictHostKeyChecking=no \
               ec2-user@${{ steps.launch-instance.outputs.public_ip }}:/tmp/auction.eif.measurements.json \
               ./measurements.json
-      
+
       - name: Extract PCRs
         id: extract-pcrs
         run: |
@@ -303,12 +303,12 @@ jobs:
           PCR1=$(jq -r '.Measurements.PCR1' measurements.json)
           PCR2=$(jq -r '.Measurements.PCR2' measurements.json)
           EIF_SHA256=$(sha256sum auction.eif | cut -d' ' -f1)
-          
+
           echo "pcr0=${PCR0}" >> "$GITHUB_OUTPUT"
           echo "pcr1=${PCR1}" >> "$GITHUB_OUTPUT"
           echo "pcr2=${PCR2}" >> "$GITHUB_OUTPUT"
           echo "eif_sha256=${EIF_SHA256}" >> "$GITHUB_OUTPUT"
-      
+
       - name: Install ORAS
         run: |
           # This ORAS runs on the GitHub runner (ubuntu-latest = amd64) to push the
@@ -320,13 +320,13 @@ jobs:
           tar -zxf oras_${VERSION}_*.tar.gz
           sudo mv oras /usr/local/bin/
           oras version
-      
+
       - name: Login to ECR
         run: |
           aws ecr get-login-password --region ${{ env.AWS_REGION }} | \
             oras login --username AWS --password-stdin \
               ${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${{ env.AWS_REGION }}.amazonaws.com
-      
+
       - name: Push EIF to ECR
         run: |
           COMMIT_SHA="${{ steps.set-sha.outputs.commit_sha }}"
@@ -340,7 +340,7 @@ jobs:
           else
             TAG_SUFFIX=""
           fi
-          
+
           oras push "${REGISTRY}/${REPO}:${COMMIT_SHA}${TAG_SUFFIX}" \
             --artifact-type application/vnd.aws.nitro.eif \
             --annotation "org.opencontainers.image.created=$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
@@ -350,15 +350,15 @@ jobs:
             --annotation "com.aws.nitro.pcr2=${{ steps.extract-pcrs.outputs.pcr2 }}" \
             auction.eif:application/octet-stream \
             measurements.json:application/json
-          
+
           if [ "${{ github.ref }}" = "refs/heads/main" ] && [ -z "${TAG_SUFFIX}" ]; then
             oras tag "${REGISTRY}/${REPO}:${COMMIT_SHA}${TAG_SUFFIX}" latest
           fi
-          
+
           oras tag "${REGISTRY}/${REPO}:${COMMIT_SHA}${TAG_SUFFIX}" "${COMMIT_SHORT}${TAG_SUFFIX}"
-      
+
       - name: Upload artifacts
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # ratchet:actions/upload-artifact@v7
         with:
           # Include the architecture so an amd64 and arm64 build of the same
           # commit don't collide on the artifact name.
@@ -367,12 +367,12 @@ jobs:
             auction.eif
             measurements.json
           retention-days: 90
-      
+
       - name: Summary
         run: |
           cat >> $GITHUB_STEP_SUMMARY << 'EOF'
           # EIF Build Complete ✅
-          
+
           ## Build Information
           - Docker Image: `${{ steps.image-uri.outputs.image_uri }}`
           - Commit: `${{ steps.set-sha.outputs.commit_sha }}`
@@ -383,11 +383,11 @@ jobs:
           | PCR0 | `${{ steps.extract-pcrs.outputs.pcr0 }}` |
           | PCR1 | `${{ steps.extract-pcrs.outputs.pcr1 }}` |
           | PCR2 | `${{ steps.extract-pcrs.outputs.pcr2 }}` |
-          
+
           ## EIF Artifact
           - SHA256: `${{ steps.extract-pcrs.outputs.eif_sha256 }}`
           EOF
-      
+
       - name: Cleanup instance
         if: always()
         run: |
@@ -401,7 +401,7 @@ jobs:
               --instance-ids "${{ steps.launch-instance.outputs.instance_id }}" \
               --cli-read-timeout 300
           fi
-      
+
       - name: Cleanup security group
         if: always()
         run: |
@@ -410,7 +410,7 @@ jobs:
             aws ec2 delete-security-group \
               --group-id "${{ steps.security-group.outputs.security_group_id }}"
           fi
-      
+
       - name: Cleanup key pair
         if: always()
         run: |
@@ -433,13 +433,13 @@ jobs:
     steps:
       - name: Generate GitHub App token
         id: app-token
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # ratchet:actions/create-github-app-token@v3
         with:
           app-id: ${{ env.GH_APP_ID }}
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
 
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # ratchet:actions/checkout@v7
         with:
           token: ${{ steps.app-token.outputs.token }}
 

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -10,27 +10,19 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
-      - uses: actions/setup-go@v6
-        with:
-          go-version: "1.25.1"
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # ratchet:actions/checkout@v7
+      - name: Install mise
+        uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # ratchet:jdx/mise-action@v4
       - name: Test
-        run: |
-          go test ./...
-  
+        run: mise run //:test
+
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
-      - uses: actions/setup-go@v6
-        with:
-          go-version: "1.25.1"
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # ratchet:actions/checkout@v7
+      - name: Install mise
+        uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # ratchet:jdx/mise-action@v4
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v9
-        with:
-          version: v2.5.0
+        run: mise run //:lint
       - name: go mod tidy
-        run: |
-          go mod tidy
-          git diff --exit-code go.mod go.sum || (echo "go.mod or go.sum needs updating. Run 'go mod tidy' locally." && exit 1)
-
+        run: mise run //:tidy

--- a/.github/workflows/ratchet.yml
+++ b/.github/workflows/ratchet.yml
@@ -1,0 +1,21 @@
+name: Ratchet
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  lint:
+    name: Ratchet Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # ratchet:actions/checkout@v7
+      - name: Install mise
+        uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # ratchet:jdx/mise-action@v4
+      - name: Lint GitHub Actions refs
+        run: mise run //:ratchet:lint
+      - name: Verify pinning leaves no diff
+        run: |
+          mise run //:ratchet:pin
+          git diff --exit-code

--- a/.mise/config.toml
+++ b/.mise/config.toml
@@ -1,0 +1,14 @@
+experimental_monorepo_root = true
+
+[monorepo]
+config_roots = ["."]
+
+[settings]
+experimental = true
+locked = true
+install_before = "7d"
+
+[tools]
+go = "1.25.1"
+golangci-lint = "2.5.0"
+"go:github.com/sethvargo/ratchet" = "0.11.4"

--- a/.mise/mise.lock
+++ b/.mise/mise.lock
@@ -1,0 +1,21 @@
+[[tools.go]]
+version = "1.25.1"
+backend = "core:go"
+"platforms.linux-arm64" = { checksum = "sha256:65a3e34fb2126f55b34e1edfc709121660e1be2dee6bdf405fc399a63a95a87d", url = "https://dl.google.com/go/go1.25.1.linux-arm64.tar.gz"}
+"platforms.linux-x64" = { checksum = "sha256:7716a0d940a0f6ae8e1f3b3f4f36299dc53e31b16840dbd171254312c41ca12e", url = "https://dl.google.com/go/go1.25.1.linux-amd64.tar.gz"}
+"platforms.macos-arm64" = { checksum = "sha256:68deebb214f39d542e518ebb0598a406ab1b5a22bba8ec9ade9f55fb4dd94a6c", url = "https://dl.google.com/go/go1.25.1.darwin-arm64.tar.gz"}
+"platforms.macos-x64" = { checksum = "sha256:1d622468f767a1b9fe1e1e67bd6ce6744d04e0c68712adc689748bbeccb126bb", url = "https://dl.google.com/go/go1.25.1.darwin-amd64.tar.gz"}
+"platforms.windows-x64" = { checksum = "sha256:4a974de310e7ee1d523d2fcedb114ba5fa75408c98eb3652023e55ccf3fa7cab", url = "https://dl.google.com/go/go1.25.1.windows-amd64.zip"}
+
+[[tools."go:github.com/sethvargo/ratchet"]]
+version = "0.11.4"
+backend = "go:github.com/sethvargo/ratchet"
+
+[[tools.golangci-lint]]
+version = "2.5.0"
+backend = "aqua:golangci/golangci-lint"
+"platforms.linux-arm64" = { checksum = "sha256:48693a98a7f4556d1117300aae240d0fe483df8d6f36dfaba56504626101a66e", url = "https://github.com/golangci/golangci-lint/releases/download/v2.5.0/golangci-lint-2.5.0-linux-arm64.tar.gz"}
+"platforms.linux-x64" = { checksum = "sha256:c77313a77e19b06123962c411d9943cc0d092bbec76b956104d18964e274902e", url = "https://github.com/golangci/golangci-lint/releases/download/v2.5.0/golangci-lint-2.5.0-linux-amd64.tar.gz"}
+"platforms.macos-arm64" = { checksum = "sha256:0b3cbdc2a2472f60b538ebccb1b2e1ae5d938a051c010591aa68c6efd3706672", url = "https://github.com/golangci/golangci-lint/releases/download/v2.5.0/golangci-lint-2.5.0-darwin-arm64.tar.gz"}
+"platforms.macos-x64" = { checksum = "sha256:a7e684872b00637d642d088dde783c1b871161a92678fcf13d07abe6b5c32e36", url = "https://github.com/golangci/golangci-lint/releases/download/v2.5.0/golangci-lint-2.5.0-darwin-amd64.tar.gz"}
+"platforms.windows-x64" = { checksum = "sha256:8d37563c2549e38135eac46e778164d2c5b1e96b9211f2087814d74ca0f358a8", url = "https://github.com/golangci/golangci-lint/releases/download/v2.5.0/golangci-lint-2.5.0-windows-amd64.zip"}

--- a/.mise/tasks/lint
+++ b/.mise/tasks/lint
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+#MISE description="Lint Go code with golangci-lint"
+# https://mise.jdx.dev/tasks/file-tasks.html
+set -euo pipefail
+
+golangci-lint run "$@"

--- a/.mise/tasks/ratchet/lint
+++ b/.mise/tasks/ratchet/lint
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+#MISE description="Lint GitHub Actions files to ensure external refs are pinned with ratchet"
+# https://mise.jdx.dev/tasks/file-tasks.html
+set -euo pipefail
+
+if [ "$#" -gt 0 ]; then
+  files=("$@")
+else
+  files=()
+  while IFS= read -r file; do
+    files+=("$file")
+  done < <(git ls-files '.github/**/*.yml' '.github/**/*.yaml')
+fi
+
+if [ "${#files[@]}" -eq 0 ]; then
+  echo "no GitHub Actions files found to lint" >&2
+  exit 1
+fi
+
+ratchet lint "${files[@]}"

--- a/.mise/tasks/ratchet/pin
+++ b/.mise/tasks/ratchet/pin
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+#MISE description="Pin GitHub Actions refs with ratchet in workflow and composite action files"
+# https://mise.jdx.dev/tasks/file-tasks.html
+set -euo pipefail
+
+if [ "$#" -gt 0 ]; then
+  files=("$@")
+else
+  files=()
+  while IFS= read -r file; do
+    files+=("$file")
+  done < <(git ls-files '.github/**/*.yml' '.github/**/*.yaml')
+fi
+
+if [ "${#files[@]}" -eq 0 ]; then
+  echo "no GitHub Actions files found to pin" >&2
+  exit 1
+fi
+
+ratchet pin "${files[@]}"

--- a/.mise/tasks/ratchet/update
+++ b/.mise/tasks/ratchet/update
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+#MISE description="Update pinned GitHub Actions refs to the latest values within their ratchet constraints"
+# https://mise.jdx.dev/tasks/file-tasks.html
+set -euo pipefail
+
+if [ "$#" -gt 0 ]; then
+  files=("$@")
+else
+  files=()
+  while IFS= read -r file; do
+    files+=("$file")
+  done < <(git ls-files '.github/**/*.yml' '.github/**/*.yaml')
+fi
+
+if [ "${#files[@]}" -eq 0 ]; then
+  echo "no GitHub Actions files found to update" >&2
+  exit 1
+fi
+
+ratchet update "${files[@]}"

--- a/.mise/tasks/ratchet/upgrade
+++ b/.mise/tasks/ratchet/upgrade
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+#MISE description="Upgrade GitHub Actions refs to the latest versions and rewrite their ratchet constraints"
+# https://mise.jdx.dev/tasks/file-tasks.html
+set -euo pipefail
+
+if [ "$#" -gt 0 ]; then
+  files=("$@")
+else
+  files=()
+  while IFS= read -r file; do
+    files+=("$file")
+  done < <(git ls-files '.github/**/*.yml' '.github/**/*.yaml')
+fi
+
+if [ "${#files[@]}" -eq 0 ]; then
+  echo "no GitHub Actions files found to upgrade" >&2
+  exit 1
+fi
+
+ratchet upgrade "${files[@]}"

--- a/.mise/tasks/test
+++ b/.mise/tasks/test
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+#MISE description="Run the Go test suite"
+# https://mise.jdx.dev/tasks/file-tasks.html
+set -euo pipefail
+
+go test ./... "$@"

--- a/.mise/tasks/tidy
+++ b/.mise/tasks/tidy
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+#MISE description="Run go mod tidy and verify go.mod/go.sum are unchanged"
+# https://mise.jdx.dev/tasks/file-tasks.html
+set -euo pipefail
+
+go mod tidy
+git diff --exit-code go.mod go.sum \
+  || (echo "go.mod or go.sum needs updating. Run 'mise run //:tidy' locally." && exit 1)


### PR DESCRIPTION
## Summary

- Add `mise` setup (`.mise/config.toml` + committed `mise.lock`) so the Go toolchain (`go` 1.25.1), `golangci-lint` (2.5.0), and `ratchet` (0.11.4) are pinned in one place and installed reproducibly.
- Add `//:test`, `//:lint`, `//:tidy` tasks plus the standard `//:ratchet:*` tasks. `go.yml` now runs these via `jdx/mise-action` instead of `setup-go` + `golangci-lint-action`, so local and CI use identical tool versions (single source of truth).
- Add the `Ratchet` workflow to enforce pinning, and upgrade every GitHub Action across all workflows to its latest version, each SHA-pinned with a `# ratchet:` constraint comment (e.g. `actions/checkout@v7`, `actions/setup-go@v6`, `actions/upload-artifact@v7`).

The `docker.yml` / `eif-build.yml` diffs are pin-only: action refs plus ratchet's 2-space YAML reindentation, no logic changes.

This mirrors the setup already used in `cloudx-io/terraform-ssp`, `cloudx-io/helmfile-ssp`, `cloudx-io/cloudexchange.ssp`, and `cloudx-io/packer-aws-ami`. A matching change for `cloudx-io/openarbiter` will follow as a separate PR.

## Test plan

- [x] `mise run //:test` passes locally
- [x] `mise run //:lint` passes locally (0 issues)
- [x] `mise run //:tidy` leaves `go.mod`/`go.sum` unchanged
- [x] `mise run //:ratchet:lint` clean; `//:ratchet:pin` produces no diff
- [x] CI green on this PR (Go + Ratchet workflows)

Made with [Cursor](https://cursor.com)