### PR TITLE
mise: use `monorepo_root` for recent mise

### DIFF
--- a/.mise/config.toml
+++ b/.mise/config.toml
@@ -1,4 +1,4 @@
-experimental_monorepo_root = true
+monorepo_root = true
 
 [monorepo]
 config_roots = ["."]


### PR DESCRIPTION
Old config field `experimental_monorepo_root` is deprecated in current versions of mise, which yields warning noise:

```
mise WARN  deprecated [config.experimental_monorepo_root]: `experimental_monorepo_root` in .../openauction/.mise/config.toml is deprecated. Use `monorepo_root` instead. This will be removed in mise 2027.12.0.
```