### PR TITLE
enclave: attest floor-rejected bid prices

### DIFF
--- a/core/auction.go
+++ b/core/auction.go
@@ -48,7 +48,11 @@ func RunAuction(
 	}
 
 	// Step 3: Enforce floor price
-	eligibleBids, floorRejectedBids := EnforceBidFloor(adjustedBids, bidFloor)
+	eligibleBids, floorRejectedBids := partitionBidsByFloor(adjustedBids, bidFloor)
+	floorRejectedBidIDs := make([]string, 0, len(floorRejectedBids))
+	for _, bid := range floorRejectedBids {
+		floorRejectedBidIDs = append(floorRejectedBidIDs, bid.ID)
+	}
 
 	// Step 4: Rank eligible bids by price with random tie-breaking
 	ranking := RankCoreBids(eligibleBids, defaultRandSource)
@@ -67,6 +71,7 @@ func RunAuction(
 		RunnerUp:            runnerUp,
 		EligibleBids:        eligibleBids,
 		PriceRejectedBidIDs: priceRejectedBids,
-		FloorRejectedBidIDs: floorRejectedBids,
+		FloorRejectedBidIDs: floorRejectedBidIDs,
+		FloorRejectedBids:   floorRejectedBids,
 	}
 }

--- a/core/auction_test.go
+++ b/core/auction_test.go
@@ -48,6 +48,32 @@ func TestRunAuction_BasicFlow(t *testing.T) {
 	check.Equal(t, "bid3", result.FloorRejectedBidIDs[0])
 }
 
+func TestRunAuction_FloorRejectedBidsUseAdjustedValues(t *testing.T) {
+	bids := []CoreBid{
+		{
+			ID:       "rejected",
+			Bidder:   "bidder_a",
+			Price:    2.0,
+			Currency: "USD",
+			DealID:   "deal-1",
+			BidType:  "banner",
+		},
+	}
+
+	result := RunAuction(bids, map[string]float64{"bidder_a": 0.5}, 1.5)
+
+	check.Equal(t, []string{"rejected"}, result.FloorRejectedBidIDs)
+	check.Equal(t, []CoreBid{{
+		ID:       "rejected",
+		Bidder:   "bidder_a",
+		Price:    1.0,
+		Currency: "USD",
+		DealID:   "deal-1",
+		BidType:  "banner",
+	}}, result.FloorRejectedBids)
+	check.Equal(t, 2.0, bids[0].Price)
+}
+
 func TestRunAuction_NoBids(t *testing.T) {
 	result := RunAuction([]CoreBid{}, nil, 0.0)
 

--- a/core/floorenforcement.go
+++ b/core/floorenforcement.go
@@ -15,20 +15,29 @@ func BidMeetsFloor(bidPrice, floorPrice float64) bool {
 	return bidPriceDecimal.GreaterThanOrEqual(floorDecimal)
 }
 
-// EnforceBidFloors filters bids based on floor price.
+// EnforceBidFloor filters bids based on floor price.
 // Returns eligible bids and IDs of rejected bids.
-// If a bidder has no floor in the map, their bids pass without enforcement.
 func EnforceBidFloor(bids []CoreBid, floor float64) (eligible []CoreBid, rejectedBidIDs []string) {
+	eligibleBids, rejectedBids := partitionBidsByFloor(bids, floor)
+	rejectedIDs := make([]string, 0, len(rejectedBids))
+	for _, bid := range rejectedBids {
+		rejectedIDs = append(rejectedIDs, bid.ID)
+	}
+
+	return eligibleBids, rejectedIDs
+}
+
+func partitionBidsByFloor(bids []CoreBid, floor float64) (eligible, rejected []CoreBid) {
 	eligibleBids := make([]CoreBid, 0, len(bids))
-	rejectedIDs := make([]string, 0)
+	rejectedBids := make([]CoreBid, 0)
 
 	for _, bid := range bids {
 		if BidMeetsFloor(bid.Price, floor) {
 			eligibleBids = append(eligibleBids, bid)
 		} else {
-			rejectedIDs = append(rejectedIDs, bid.ID)
+			rejectedBids = append(rejectedBids, bid)
 		}
 	}
 
-	return eligibleBids, rejectedIDs
+	return eligibleBids, rejectedBids
 }

--- a/core/types.go
+++ b/core/types.go
@@ -34,6 +34,9 @@ type AuctionResult struct {
 
 	// FloorRejectedBidIDs contains IDs of bids that failed floor enforcement
 	FloorRejectedBidIDs []string
+
+	// FloorRejectedBids contains post-adjustment bids that failed floor enforcement
+	FloorRejectedBids []CoreBid
 }
 
 // ExcludedBid represents a bid that was excluded from the auction (floor rejection, decryption failure, etc.)

--- a/enclave/auction.go
+++ b/enclave/auction.go
@@ -81,7 +81,14 @@ func ProcessAuction(attester EnclaveAttester, req enclaveapi.EnclaveAuctionReque
 	winner := auctionResult.Winner
 	runnerUp := auctionResult.RunnerUp
 
-	coseAttestation, attestationUs, err := GenerateTEEProofs(attester, req, unencryptedBids, winner, runnerUp)
+	coseAttestation, attestationUs, err := GenerateTEEProofs(
+		attester,
+		req,
+		unencryptedBids,
+		winner,
+		runnerUp,
+		auctionResult.FloorRejectedBids,
+	)
 	processingTime := time.Since(startTime).Milliseconds()
 
 	log.Printf("INFO: Auction complete: winner=%s (%.2f), runner-up=%s (%.2f), processing=%dms",

--- a/enclave/auction.go
+++ b/enclave/auction.go
@@ -46,6 +46,15 @@ func ProcessAuction(attester EnclaveAttester, req enclaveapi.EnclaveAuctionReque
 	startTime := time.Now()
 	log.Printf("INFO: Processing auction %s with %d bids", req.AuctionID, len(req.Bids))
 
+	if err := validateUniqueBidIDs(req.Bids); err != nil {
+		return enclaveapi.EnclaveAuctionResponse{
+			Type:           "auction_response",
+			Success:        false,
+			Message:        err.Error(),
+			ProcessingTime: time.Since(startTime).Milliseconds(),
+		}
+	}
+
 	// Validate bid floor is non-negative
 	if req.BidFloor < 0.0 {
 		return enclaveapi.EnclaveAuctionResponse{
@@ -116,6 +125,17 @@ func ProcessAuction(attester EnclaveAttester, req enclaveapi.EnclaveAuctionReque
 		ProcessingTime:        processingTime,
 		AttestationUs:         attestationUs,
 	}
+}
+
+func validateUniqueBidIDs(bids []enclaveapi.EncryptedCoreBid) error {
+	seen := make(map[string]struct{}, len(bids))
+	for _, bid := range bids {
+		if _, exists := seen[bid.ID]; exists {
+			return fmt.Errorf("duplicate bid ID %q", bid.ID)
+		}
+		seen[bid.ID] = struct{}{}
+	}
+	return nil
 }
 
 func getBidderName(bid *core.CoreBid) string {

--- a/enclave/auction_test.go
+++ b/enclave/auction_test.go
@@ -1,7 +1,9 @@
 package main
 
 import (
+	"bytes"
 	"encoding/base64"
+	"encoding/json"
 	"fmt"
 	"slices"
 	"testing"
@@ -310,6 +312,44 @@ func TestProcessAuction_BidFloorEnforcement(t *testing.T) {
 	check.NotNil(t, attestationDoc.UserData.RunnerUp)
 	check.Equal(t, "bid2", attestationDoc.UserData.RunnerUp.ID)
 	check.Equal(t, 2.50, attestationDoc.UserData.RunnerUp.Price)
+}
+
+func TestProcessAuction_AttestsDecryptedAdjustedFloorRejectedBid(t *testing.T) {
+	mockAttester := CreateMockEnclave(t)
+	keyManager := newTestKeyManager(t)
+	encryptedBid := encryptPriceBid(t, keyManager, "bid1", "private_bidder", `{"price": 2.00}`)
+	encryptedBid.Price = 999.0
+	encryptedBid.DealID = "deal-1"
+	encryptedBid.BidType = "banner"
+
+	req := enclaveapi.EnclaveAuctionRequest{
+		Type:              "auction_request",
+		AuctionID:         "test_attested_floor_rejection",
+		RoundIDString:     "test_attested_floor_rejection-1",
+		Bids:              []enclaveapi.EncryptedCoreBid{encryptedBid},
+		AdjustmentFactors: map[string]float64{"private_bidder": 0.5},
+		BidFloor:          1.5,
+		Timestamp:         time.Now(),
+	}
+
+	response := ProcessAuction(mockAttester, req, keyManager)
+
+	check.True(t, response.Success)
+	check.Equal(t, []string{"bid1"}, response.FloorRejectedBidIDs)
+
+	attestationDoc := parseAttestationFromResponse(t, response)
+	check.Equal(t, []enclaveapi.CoreBidWithoutBidder{{
+		ID:       "bid1",
+		Price:    1.0,
+		Currency: "USD",
+		DealID:   "deal-1",
+		BidType:  "banner",
+	}}, attestationDoc.UserData.FloorRejectedBids)
+
+	userDataJSON, err := json.Marshal(attestationDoc.UserData)
+	check.NoError(t, err)
+	check.True(t, !bytes.Contains(userDataJSON, []byte(`"bidder"`)))
+	check.True(t, !bytes.Contains(userDataJSON, []byte(`999`)))
 }
 
 // TestProcessAuction_BidFloorAllRejected tests when all bids are below floor

--- a/enclave/auction_test.go
+++ b/enclave/auction_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	enclave "github.com/edgebitio/nitro-enclaves-sdk-go"
 	"github.com/peterldowns/testy/assert"
 	"github.com/peterldowns/testy/check"
 
@@ -205,6 +206,56 @@ func TestProcessAuction_ThreeBids(t *testing.T) {
 	check.True(t, slices.Contains(attestationDoc.UserData.BidHashes, hash1))
 	check.True(t, slices.Contains(attestationDoc.UserData.BidHashes, hash2))
 	check.True(t, slices.Contains(attestationDoc.UserData.BidHashes, hash3))
+}
+
+func TestProcessAuction_RejectsCrossBidderDuplicateIDs(t *testing.T) {
+	attestCalled := false
+	attester := &MockEnclaveHandle{
+		AttestFunc: func(enclave.AttestationOptions) ([]byte, error) {
+			attestCalled = true
+			return nil, nil
+		},
+	}
+	req := enclaveapi.EnclaveAuctionRequest{
+		AuctionID: "duplicate-cross-bidder",
+		Bids: []enclaveapi.EncryptedCoreBid{
+			{CoreBid: core.CoreBid{ID: "shared", Bidder: "bidder-a", Price: 3}},
+			{CoreBid: core.CoreBid{ID: "shared", Bidder: "bidder-b", Price: 2}},
+		},
+	}
+
+	response := ProcessAuction(attester, req, nil)
+
+	check.False(t, response.Success)
+	check.Equal(t, `duplicate bid ID "shared"`, response.Message)
+	check.Equal(t, enclaveapi.AttestationCOSEBase64(""), response.AttestationCOSEBase64)
+	check.False(t, attestCalled)
+}
+
+func TestProcessAuction_RejectsWinnerFloorRejectedIDAmbiguity(t *testing.T) {
+	attestCalled := false
+	attester := &MockEnclaveHandle{
+		AttestFunc: func(enclave.AttestationOptions) ([]byte, error) {
+			attestCalled = true
+			return nil, nil
+		},
+	}
+	req := enclaveapi.EnclaveAuctionRequest{
+		AuctionID: "duplicate-winner-rejected",
+		BidFloor:  2,
+		Bids: []enclaveapi.EncryptedCoreBid{
+			{CoreBid: core.CoreBid{ID: "ambiguous", Bidder: "bidder-a", Price: 3}},
+			{CoreBid: core.CoreBid{ID: "ambiguous", Bidder: "bidder-a", Price: 1}},
+		},
+	}
+
+	response := ProcessAuction(attester, req, nil)
+
+	check.False(t, response.Success)
+	check.Equal(t, `duplicate bid ID "ambiguous"`, response.Message)
+	check.Equal(t, []string(nil), response.FloorRejectedBidIDs)
+	check.Equal(t, enclaveapi.AttestationCOSEBase64(""), response.AttestationCOSEBase64)
+	check.False(t, attestCalled)
 }
 
 func TestGetBidderName(t *testing.T) {

--- a/enclave/auction_test.go
+++ b/enclave/auction_test.go
@@ -338,18 +338,22 @@ func TestProcessAuction_AttestsDecryptedAdjustedFloorRejectedBid(t *testing.T) {
 	check.Equal(t, []string{"bid1"}, response.FloorRejectedBidIDs)
 
 	attestationDoc := parseAttestationFromResponse(t, response)
-	check.Equal(t, []enclaveapi.CoreBidWithoutBidder{{
-		ID:       "bid1",
-		Price:    1.0,
-		Currency: "USD",
-		DealID:   "deal-1",
-		BidType:  "banner",
+	check.Equal(t, []enclaveapi.AttestedFloorRejectedBid{{
+		ID:    "bid1",
+		Price: 1.0,
 	}}, attestationDoc.UserData.FloorRejectedBids)
 
 	userDataJSON, err := json.Marshal(attestationDoc.UserData)
 	check.NoError(t, err)
-	check.True(t, !bytes.Contains(userDataJSON, []byte(`"bidder"`)))
-	check.True(t, !bytes.Contains(userDataJSON, []byte(`999`)))
+	for _, value := range [][]byte{
+		[]byte(`"bidder"`),
+		[]byte(`"currency"`),
+		[]byte(`"deal_id"`),
+		[]byte(`"bid_type"`),
+		[]byte(`999`),
+	} {
+		check.True(t, !bytes.Contains(userDataJSON, value))
+	}
 }
 
 // TestProcessAuction_BidFloorAllRejected tests when all bids are below floor

--- a/enclave/proofs.go
+++ b/enclave/proofs.go
@@ -17,6 +17,11 @@ import (
 	"github.com/cloudx-io/openauction/enclaveapi"
 )
 
+const (
+	maxAttestationUserDataBytes      = 1024
+	maxAttestedFloorRejectedBidCount = 4
+)
+
 // EnclaveAttester interface for dependency injection and testing
 type EnclaveAttester interface {
 	Attest(options enclave.AttestationOptions) ([]byte, error)
@@ -128,6 +133,14 @@ func GenerateAttestation(
 	runnerUp *core.CoreBid,
 	floorRejectedBids []core.CoreBid,
 ) (enclaveapi.AttestationCOSE, *float64, error) {
+	if len(floorRejectedBids) > maxAttestedFloorRejectedBidCount {
+		return nil, nil, fmt.Errorf(
+			"floor-rejected bid count %d exceeds attestation limit %d",
+			len(floorRejectedBids),
+			maxAttestedFloorRejectedBidCount,
+		)
+	}
+
 	now := time.Now()
 
 	// Create the user data that will be embedded in the attestation
@@ -156,6 +169,13 @@ func GenerateAttestation(
 	userDataBytes, err := json.Marshal(userData)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to marshal user data: %w", err)
+	}
+	if len(userDataBytes) > maxAttestationUserDataBytes {
+		return nil, nil, fmt.Errorf(
+			"attestation user data is %d bytes, exceeds NSM limit %d",
+			len(userDataBytes),
+			maxAttestationUserDataBytes,
+		)
 	}
 	randomNonce, err := generateNonce()
 	if err != nil {

--- a/enclave/proofs.go
+++ b/enclave/proofs.go
@@ -100,16 +100,19 @@ func stripBidderName(bid *core.CoreBid) *enclaveapi.CoreBidWithoutBidder {
 	}
 }
 
-func stripBidderNames(bids []core.CoreBid) []enclaveapi.CoreBidWithoutBidder {
+func attestFloorRejectedBids(bids []core.CoreBid) []enclaveapi.AttestedFloorRejectedBid {
 	if len(bids) == 0 {
 		return nil
 	}
 
-	strippedBids := make([]enclaveapi.CoreBidWithoutBidder, 0, len(bids))
-	for i := range bids {
-		strippedBids = append(strippedBids, *stripBidderName(&bids[i]))
+	attestedBids := make([]enclaveapi.AttestedFloorRejectedBid, 0, len(bids))
+	for _, bid := range bids {
+		attestedBids = append(attestedBids, enclaveapi.AttestedFloorRejectedBid{
+			ID:    bid.ID,
+			Price: bid.Price,
+		})
 	}
-	return strippedBids
+	return attestedBids
 }
 
 func GenerateAttestation(
@@ -139,7 +142,7 @@ func GenerateAttestation(
 		BidHashNonce:           bidHashNonce,
 		Winner:                 stripBidderName(winner),
 		RunnerUp:               stripBidderName(runnerUp),
-		FloorRejectedBids:      stripBidderNames(floorRejectedBids),
+		FloorRejectedBids:      attestFloorRejectedBids(floorRejectedBids),
 		RequestNonce:           requestNonce,
 		AdjustmentFactorsNonce: adjustmentFactorsNonce,
 		Timestamp:              now,

--- a/enclave/proofs.go
+++ b/enclave/proofs.go
@@ -22,7 +22,7 @@ type EnclaveAttester interface {
 	Attest(options enclave.AttestationOptions) ([]byte, error)
 }
 
-func GenerateTEEProofs(attester EnclaveAttester, req enclaveapi.EnclaveAuctionRequest, unencryptedBids []core.CoreBid, winner, runnerUp *core.CoreBid) (enclaveapi.AttestationCOSE, *float64, error) {
+func GenerateTEEProofs(attester EnclaveAttester, req enclaveapi.EnclaveAuctionRequest, unencryptedBids []core.CoreBid, winner, runnerUp *core.CoreBid, floorRejectedBids []core.CoreBid) (enclaveapi.AttestationCOSE, *float64, error) {
 	bidHashNonce, err := generateNonce()
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to generate bid hash nonce: %w", err)
@@ -50,7 +50,7 @@ func GenerateTEEProofs(attester EnclaveAttester, req enclaveapi.EnclaveAuctionRe
 	adjustmentFactorsHash := calculateAdjustmentFactorsHash(req.AdjustmentFactors, adjustmentFactorsNonce)
 
 	return GenerateAttestation(attester, req, bidHashes, requestHash, adjustmentFactorsHash,
-		bidHashNonce, requestNonce, adjustmentFactorsNonce, winner, runnerUp)
+		bidHashNonce, requestNonce, adjustmentFactorsNonce, winner, runnerUp, floorRejectedBids)
 }
 
 // generateSecureRandomBytes generates cryptographically secure random bytes
@@ -100,6 +100,18 @@ func stripBidderName(bid *core.CoreBid) *enclaveapi.CoreBidWithoutBidder {
 	}
 }
 
+func stripBidderNames(bids []core.CoreBid) []enclaveapi.CoreBidWithoutBidder {
+	if len(bids) == 0 {
+		return nil
+	}
+
+	strippedBids := make([]enclaveapi.CoreBidWithoutBidder, 0, len(bids))
+	for i := range bids {
+		strippedBids = append(strippedBids, *stripBidderName(&bids[i]))
+	}
+	return strippedBids
+}
+
 func GenerateAttestation(
 	attester EnclaveAttester,
 	req enclaveapi.EnclaveAuctionRequest,
@@ -111,6 +123,7 @@ func GenerateAttestation(
 	adjustmentFactorsNonce string,
 	winner *core.CoreBid,
 	runnerUp *core.CoreBid,
+	floorRejectedBids []core.CoreBid,
 ) (enclaveapi.AttestationCOSE, *float64, error) {
 	now := time.Now()
 
@@ -126,6 +139,7 @@ func GenerateAttestation(
 		BidHashNonce:           bidHashNonce,
 		Winner:                 stripBidderName(winner),
 		RunnerUp:               stripBidderName(runnerUp),
+		FloorRejectedBids:      stripBidderNames(floorRejectedBids),
 		RequestNonce:           requestNonce,
 		AdjustmentFactorsNonce: adjustmentFactorsNonce,
 		Timestamp:              now,

--- a/enclave/proofs_test.go
+++ b/enclave/proofs_test.go
@@ -113,7 +113,7 @@ func TestGenerateAttestation(t *testing.T) {
 	// Test with nil enclave handle (error case)
 	bidHashes := []string{"hash1", "hash2"}
 	coseBytes, _, err := GenerateAttestation(nil, req, bidHashes, "test_request_hash", "test_adj_hash",
-		"test_bid_nonce", "test_req_nonce", "test_adj_nonce", winner, runnerUp)
+		"test_bid_nonce", "test_req_nonce", "test_adj_nonce", winner, runnerUp, nil)
 
 	// Should fail with nil enclave handle
 	check.Error(t, err)
@@ -143,7 +143,7 @@ func TestGenerateAttestationWithMock(t *testing.T) {
 
 	// Test successful attestation generation with mock
 	coseBytes, attestationUs, err := GenerateAttestation(mockEnclave, req, []string{bidHash}, "test_request_hash", "test_adj_hash",
-		bidHashNonce, "test_req_nonce", "test_adj_nonce", winner, nil)
+		bidHashNonce, "test_req_nonce", "test_adj_nonce", winner, nil, nil)
 
 	// Should succeed with mock enclave
 	check.NoError(t, err)
@@ -222,7 +222,7 @@ func TestGenerateAttestationWithEncryptedBids(t *testing.T) {
 
 	// Test successful attestation generation with encrypted bids
 	coseBytes, attestationUs, err := GenerateAttestation(mockEnclave, req, bidHashes, "test_request_hash", "test_adj_hash",
-		bidHashNonce, "test_req_nonce", "test_adj_nonce", winner, runnerUp)
+		bidHashNonce, "test_req_nonce", "test_adj_nonce", winner, runnerUp, nil)
 
 	// Should succeed with mock enclave
 	check.NoError(t, err)
@@ -488,7 +488,7 @@ func TestGenerateAttestationWithMixedBidTypes(t *testing.T) {
 
 	// Generate attestation for mixed bid scenario
 	coseBytes, _, err := GenerateAttestation(mockEnclave, req, bidHashes, "mixed_request_hash", "mixed_adj_hash",
-		bidHashNonce, "mixed_req_nonce", "mixed_adj_nonce", winner, runnerUp)
+		bidHashNonce, "mixed_req_nonce", "mixed_adj_nonce", winner, runnerUp, nil)
 
 	// Verify successful attestation generation
 	check.NoError(t, err)

--- a/enclave/proofs_test.go
+++ b/enclave/proofs_test.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"testing"
 
+	enclave "github.com/edgebitio/nitro-enclaves-sdk-go"
 	"github.com/peterldowns/testy/check"
 
 	"github.com/cloudx-io/openauction/core"
@@ -119,6 +120,65 @@ func TestGenerateAttestation(t *testing.T) {
 	check.Error(t, err)
 	check.Nil(t, coseBytes)
 	check.True(t, strings.Contains(err.Error(), "enclave attester is nil"))
+}
+
+func TestGenerateAttestationRejectsLimitsBeforeAttest(t *testing.T) {
+	tests := []struct {
+		name              string
+		req               enclaveapi.EnclaveAuctionRequest
+		floorRejectedBids []core.CoreBid
+		expectedError     string
+	}{
+		{
+			name: "floor-rejected bid count",
+			req:  enclaveapi.EnclaveAuctionRequest{AuctionID: "auction"},
+			floorRejectedBids: []core.CoreBid{
+				{ID: "bid1", Price: 1},
+				{ID: "bid2", Price: 1},
+				{ID: "bid3", Price: 1},
+				{ID: "bid4", Price: 1},
+				{ID: "bid5", Price: 1},
+			},
+			expectedError: "floor-rejected bid count 5 exceeds attestation limit 4",
+		},
+		{
+			name:          "encoded user data",
+			req:           enclaveapi.EnclaveAuctionRequest{AuctionID: strings.Repeat("a", maxAttestationUserDataBytes)},
+			expectedError: "exceeds NSM limit 1024",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			attestCalled := false
+			attester := &MockEnclaveHandle{
+				AttestFunc: func(enclave.AttestationOptions) ([]byte, error) {
+					attestCalled = true
+					return nil, nil
+				},
+			}
+
+			coseBytes, attestationUs, err := GenerateAttestation(
+				attester,
+				tt.req,
+				nil,
+				"request_hash",
+				"adjustment_factors_hash",
+				"bid_hash_nonce",
+				"request_nonce",
+				"adjustment_factors_nonce",
+				nil,
+				nil,
+				tt.floorRejectedBids,
+			)
+
+			check.Error(t, err)
+			check.True(t, strings.Contains(err.Error(), tt.expectedError))
+			check.Nil(t, coseBytes)
+			check.Nil(t, attestationUs)
+			check.False(t, attestCalled)
+		})
+	}
 }
 
 func TestGenerateAttestationWithMock(t *testing.T) {

--- a/enclaveapi/types.go
+++ b/enclaveapi/types.go
@@ -101,19 +101,20 @@ type CoreBidWithoutBidder struct {
 
 // AuctionAttestationUserData represents the auction-specific data embedded in the attestation
 type AuctionAttestationUserData struct {
-	AuctionID              string                `json:"auction_id"`
-	RoundID                int                   `json:"round_id"`
-	RoundIDString          string                `json:"round_id_string,omitempty"`
-	BidHashes              []string              `json:"bid_hashes"`
-	RequestHash            string                `json:"request_hash"`
-	AdjustmentFactorsHash  string                `json:"adjustment_factors_hash"`
-	BidFloor               float64               `json:"bid_floor"`
-	BidHashNonce           string                `json:"bid_hash_nonce"`
-	Winner                 *CoreBidWithoutBidder `json:"winner,omitempty"`
-	RunnerUp               *CoreBidWithoutBidder `json:"runner_up,omitempty"`
-	RequestNonce           string                `json:"request_nonce"`
-	AdjustmentFactorsNonce string                `json:"adjustment_factors_nonce"`
-	Timestamp              time.Time             `json:"timestamp"`
+	AuctionID              string                 `json:"auction_id"`
+	RoundID                int                    `json:"round_id"`
+	RoundIDString          string                 `json:"round_id_string,omitempty"`
+	BidHashes              []string               `json:"bid_hashes"`
+	RequestHash            string                 `json:"request_hash"`
+	AdjustmentFactorsHash  string                 `json:"adjustment_factors_hash"`
+	BidFloor               float64                `json:"bid_floor"`
+	BidHashNonce           string                 `json:"bid_hash_nonce"`
+	Winner                 *CoreBidWithoutBidder  `json:"winner,omitempty"`
+	RunnerUp               *CoreBidWithoutBidder  `json:"runner_up,omitempty"`
+	FloorRejectedBids      []CoreBidWithoutBidder `json:"floor_rejected_bids,omitempty"`
+	RequestNonce           string                 `json:"request_nonce"`
+	AdjustmentFactorsNonce string                 `json:"adjustment_factors_nonce"`
+	Timestamp              time.Time              `json:"timestamp"`
 }
 
 // URLEncode encodes attestation for URLs

--- a/enclaveapi/types.go
+++ b/enclaveapi/types.go
@@ -99,22 +99,28 @@ type CoreBidWithoutBidder struct {
 	BidType  string  `json:"bid_type,omitempty"`
 }
 
+// AttestedFloorRejectedBid contains the trusted values needed to recover a rejected bid.
+type AttestedFloorRejectedBid struct {
+	ID    string  `json:"id"`
+	Price float64 `json:"price"`
+}
+
 // AuctionAttestationUserData represents the auction-specific data embedded in the attestation
 type AuctionAttestationUserData struct {
-	AuctionID              string                 `json:"auction_id"`
-	RoundID                int                    `json:"round_id"`
-	RoundIDString          string                 `json:"round_id_string,omitempty"`
-	BidHashes              []string               `json:"bid_hashes"`
-	RequestHash            string                 `json:"request_hash"`
-	AdjustmentFactorsHash  string                 `json:"adjustment_factors_hash"`
-	BidFloor               float64                `json:"bid_floor"`
-	BidHashNonce           string                 `json:"bid_hash_nonce"`
-	Winner                 *CoreBidWithoutBidder  `json:"winner,omitempty"`
-	RunnerUp               *CoreBidWithoutBidder  `json:"runner_up,omitempty"`
-	FloorRejectedBids      []CoreBidWithoutBidder `json:"floor_rejected_bids,omitempty"`
-	RequestNonce           string                 `json:"request_nonce"`
-	AdjustmentFactorsNonce string                 `json:"adjustment_factors_nonce"`
-	Timestamp              time.Time              `json:"timestamp"`
+	AuctionID              string                     `json:"auction_id"`
+	RoundID                int                        `json:"round_id"`
+	RoundIDString          string                     `json:"round_id_string,omitempty"`
+	BidHashes              []string                   `json:"bid_hashes"`
+	RequestHash            string                     `json:"request_hash"`
+	AdjustmentFactorsHash  string                     `json:"adjustment_factors_hash"`
+	BidFloor               float64                    `json:"bid_floor"`
+	BidHashNonce           string                     `json:"bid_hash_nonce"`
+	Winner                 *CoreBidWithoutBidder      `json:"winner,omitempty"`
+	RunnerUp               *CoreBidWithoutBidder      `json:"runner_up,omitempty"`
+	FloorRejectedBids      []AttestedFloorRejectedBid `json:"floor_rejected_bids,omitempty"`
+	RequestNonce           string                     `json:"request_nonce"`
+	AdjustmentFactorsNonce string                     `json:"adjustment_factors_nonce"`
+	Timestamp              time.Time                  `json:"timestamp"`
 }
 
 // URLEncode encodes attestation for URLs

--- a/enclaveapi/types_test.go
+++ b/enclaveapi/types_test.go
@@ -243,17 +243,16 @@ func TestAuctionAttestationUserData_FloorRejectedBidsJSON(t *testing.T) {
 	check.True(t, !strings.Contains(string(withoutRejectedBids), "floor_rejected_bids"))
 
 	withRejectedBids, err := json.Marshal(AuctionAttestationUserData{
-		FloorRejectedBids: []CoreBidWithoutBidder{{
-			ID:       "bid1",
-			Price:    1.25,
-			Currency: "USD",
-			DealID:   "deal-1",
-			BidType:  "banner",
+		FloorRejectedBids: []AttestedFloorRejectedBid{{
+			ID:    "bid1",
+			Price: 1.25,
 		}},
 	})
 	check.NoError(t, err)
-	check.True(t, strings.Contains(string(withRejectedBids), `"floor_rejected_bids":[{"id":"bid1","price":1.25,"currency":"USD","deal_id":"deal-1","bid_type":"banner"}]`))
-	check.True(t, !strings.Contains(string(withRejectedBids), `"bidder"`))
+	check.True(t, strings.Contains(string(withRejectedBids), `"floor_rejected_bids":[{"id":"bid1","price":1.25}]`))
+	for _, field := range []string{`"bidder"`, `"currency"`, `"deal_id"`, `"bid_type"`} {
+		check.True(t, !strings.Contains(string(withRejectedBids), field))
+	}
 }
 
 // TestAttestationTypes_RoundTrip tests complete round-trip conversions

--- a/enclaveapi/types_test.go
+++ b/enclaveapi/types_test.go
@@ -1,6 +1,7 @@
 package enclaveapi
 
 import (
+	"encoding/json"
 	"strings"
 	"testing"
 
@@ -234,6 +235,25 @@ func TestAttestationTypes_JSONMarshaling(t *testing.T) {
 
 	encoded := jsonData.EncodeBase64()
 	check.Equal(t, original.Attestation, encoded)
+}
+
+func TestAuctionAttestationUserData_FloorRejectedBidsJSON(t *testing.T) {
+	withoutRejectedBids, err := json.Marshal(AuctionAttestationUserData{})
+	check.NoError(t, err)
+	check.True(t, !strings.Contains(string(withoutRejectedBids), "floor_rejected_bids"))
+
+	withRejectedBids, err := json.Marshal(AuctionAttestationUserData{
+		FloorRejectedBids: []CoreBidWithoutBidder{{
+			ID:       "bid1",
+			Price:    1.25,
+			Currency: "USD",
+			DealID:   "deal-1",
+			BidType:  "banner",
+		}},
+	})
+	check.NoError(t, err)
+	check.True(t, strings.Contains(string(withRejectedBids), `"floor_rejected_bids":[{"id":"bid1","price":1.25,"currency":"USD","deal_id":"deal-1","bid_type":"banner"}]`))
+	check.True(t, !strings.Contains(string(withRejectedBids), `"bidder"`))
 }
 
 // TestAttestationTypes_RoundTrip tests complete round-trip conversions


### PR DESCRIPTION
## Context
- Encrypted floor-rejected bids previously lost their trusted prices before downstream analytics could record them.
- The signed attestation now carries only each rejected bid ID and adjusted price, while retaining legacy response IDs.
- Duplicate bid IDs and payloads beyond four rejected bids or 1024 encoded bytes fail closed before attestation.
- Deploy this producer change before enabling the matching consumer that reads `floor_rejected_bids` from attestation user data.

## Testing
- [x] `mise run test`: covers adjusted encrypted prices, legacy IDs, duplicate rejection, and attestation limits.
- [x] `mise run lint`: reports no issues across the changed core, enclave, and API packages.
- [x] `git diff --check origin/main...HEAD`: no whitespace errors in the committed diff.
- [ ] Enclave deployment: required before consumers can observe nonzero encrypted rejection prices.