### PR TITLE
Echo bidder identity and qualify pre-auction rejections on the auction response

### DIFF
--- a/core/auction.go
+++ b/core/auction.go
@@ -1,19 +1,20 @@
 package core
 
 // validateBidPrices filters bids with invalid (non-positive) prices.
-func validateBidPrices(bids []CoreBid) (valid []CoreBid, rejectedBidIDs []string) {
+// Returns valid bids and bidder-qualified references to the rejected bids.
+func validateBidPrices(bids []CoreBid) (valid []CoreBid, rejected []BidRef) {
 	validBids := make([]CoreBid, 0, len(bids))
-	rejectedIDs := make([]string, 0)
+	rejectedBids := make([]BidRef, 0)
 
 	for _, bid := range bids {
 		if bid.Price > 0.0 {
 			validBids = append(validBids, bid)
 		} else {
-			rejectedIDs = append(rejectedIDs, bid.ID)
+			rejectedBids = append(rejectedBids, BidRef{BidID: bid.ID, Bidder: bid.Bidder})
 		}
 	}
 
-	return validBids, rejectedIDs
+	return validBids, rejectedBids
 }
 
 // RunAuction executes the core auction logic: price validation → adjustment → floor enforcement → ranking.
@@ -39,7 +40,7 @@ func RunAuction(
 	bidFloor float64,
 ) *AuctionResult {
 	// Step 1: Validate bid prices
-	validBids, priceRejectedBids := validateBidPrices(bids)
+	validBids, priceRejected := validateBidPrices(bids)
 
 	// Step 2: Apply bid adjustment factors
 	adjustedBids := validBids
@@ -48,7 +49,7 @@ func RunAuction(
 	}
 
 	// Step 3: Enforce floor price
-	eligibleBids, floorRejectedBids := EnforceBidFloor(adjustedBids, bidFloor)
+	eligibleBids, floorRejected := EnforceBidFloor(adjustedBids, bidFloor)
 
 	// Step 4: Rank eligible bids by price with random tie-breaking
 	ranking := RankCoreBids(eligibleBids, defaultRandSource)
@@ -66,7 +67,9 @@ func RunAuction(
 		Winner:              winner,
 		RunnerUp:            runnerUp,
 		EligibleBids:        eligibleBids,
-		PriceRejectedBidIDs: priceRejectedBids,
-		FloorRejectedBidIDs: floorRejectedBids,
+		PriceRejected:       priceRejected,
+		FloorRejected:       floorRejected,
+		PriceRejectedBidIDs: bidRefIDs(priceRejected),
+		FloorRejectedBidIDs: bidRefIDs(floorRejected),
 	}
 }

--- a/core/auction_test.go
+++ b/core/auction_test.go
@@ -58,6 +58,35 @@ func TestRunAuction_NoBids(t *testing.T) {
 	check.Equal(t, 0, len(result.FloorRejectedBidIDs))
 }
 
+// TestRunAuction_RejectionsQualifiedByBidder: when two bidders share a bid ID
+// and only one of them is rejected, the bare ID cannot say which. The
+// bidder-qualified rejections can, and the winner keeps the shared ID.
+func TestRunAuction_RejectionsQualifiedByBidder(t *testing.T) {
+	const sharedBidID = "1"
+
+	bids := []CoreBid{
+		{ID: sharedBidID, Bidder: "aaa_bidder", Price: 2.26},
+		{ID: sharedBidID, Bidder: "zzz_bidder", Price: 0.10},
+		{ID: "2", Bidder: "mmm_bidder", Price: -1.0},
+	}
+
+	result := RunAuction(bids, nil, 1.00)
+
+	check.NotNil(t, result.Winner)
+	check.Equal(t, "aaa_bidder", result.Winner.Bidder)
+	check.Equal(t, sharedBidID, result.Winner.ID)
+
+	// Only zzz_bidder was below floor, even though the winner shares its bid ID.
+	check.Equal(t, []BidRef{{BidID: sharedBidID, Bidder: "zzz_bidder"}}, result.FloorRejected)
+	check.Equal(t, []BidRef{{BidID: "2", Bidder: "mmm_bidder"}}, result.PriceRejected)
+
+	// The deprecated ID-only views stay populated for existing callers, and show
+	// exactly the ambiguity that motivated the qualified fields: the floor
+	// rejection is reported under an ID the winner also holds.
+	check.Equal(t, []string{sharedBidID}, result.FloorRejectedBidIDs)
+	check.Equal(t, []string{"2"}, result.PriceRejectedBidIDs)
+}
+
 func TestRunAuction_SingleBid(t *testing.T) {
 	bids := []CoreBid{
 		{ID: "bid1", Bidder: "bidder_a", Price: 2.0},

--- a/core/floorenforcement.go
+++ b/core/floorenforcement.go
@@ -16,19 +16,19 @@ func BidMeetsFloor(bidPrice, floorPrice float64) bool {
 }
 
 // EnforceBidFloors filters bids based on floor price.
-// Returns eligible bids and IDs of rejected bids.
+// Returns eligible bids and bidder-qualified references to the rejected bids.
 // If a bidder has no floor in the map, their bids pass without enforcement.
-func EnforceBidFloor(bids []CoreBid, floor float64) (eligible []CoreBid, rejectedBidIDs []string) {
+func EnforceBidFloor(bids []CoreBid, floor float64) (eligible []CoreBid, rejected []BidRef) {
 	eligibleBids := make([]CoreBid, 0, len(bids))
-	rejectedIDs := make([]string, 0)
+	rejectedBids := make([]BidRef, 0)
 
 	for _, bid := range bids {
 		if BidMeetsFloor(bid.Price, floor) {
 			eligibleBids = append(eligibleBids, bid)
 		} else {
-			rejectedIDs = append(rejectedIDs, bid.ID)
+			rejectedBids = append(rejectedBids, BidRef{BidID: bid.ID, Bidder: bid.Bidder})
 		}
 	}
 
-	return eligibleBids, rejectedIDs
+	return eligibleBids, rejectedBids
 }

--- a/core/floorenforcement_test.go
+++ b/core/floorenforcement_test.go
@@ -134,9 +134,9 @@ func TestEnforceBidFloors_PreservesOtherFields(t *testing.T) {
 	check.Equal(t, "deal123", result[0].DealID)
 	check.Equal(t, "banner", result[0].BidType)
 
-	// Verify rejected bid ID is returned
+	// Verify the rejected bid is returned qualified by its bidder
 	check.Equal(t, 1, len(rejected))
-	check.Equal(t, "bid2", rejected[0])
+	check.Equal(t, BidRef{BidID: "bid2", Bidder: "bidder_2"}, rejected[0])
 }
 
 func TestEnforceBidFloors_MonetaryPrecisionConsistency(t *testing.T) {
@@ -150,5 +150,5 @@ func TestEnforceBidFloors_MonetaryPrecisionConsistency(t *testing.T) {
 	eligible, rejected := EnforceBidFloor(bids, floor)
 
 	check.Equal(t, bids, eligible)
-	check.Equal(t, []string{}, rejected)
+	check.Equal(t, []BidRef{}, rejected)
 }

--- a/core/types.go
+++ b/core/types.go
@@ -17,6 +17,26 @@ type CoreRankingResult struct {
 	SortedBidders []string            `json:"sorted_bidders"`
 }
 
+// BidRef identifies a bid by the bidder that submitted it.
+//
+// Bid IDs are only unique per bidder — many DSPs number their bids "1", "2" —
+// so a bare ID cannot be attributed back to a seat when two bidders in the same
+// round share one. Every bid reference that crosses a package or process
+// boundary carries the bidder alongside the ID for that reason.
+type BidRef struct {
+	BidID  string `json:"bid_id"`
+	Bidder string `json:"bidder,omitempty"`
+}
+
+// bidRefIDs projects refs down to bare bid IDs.
+func bidRefIDs(refs []BidRef) []string {
+	ids := make([]string, 0, len(refs))
+	for _, ref := range refs {
+		ids = append(ids, ref.BidID)
+	}
+	return ids
+}
+
 // AuctionResult contains the complete results of running an auction.
 // This unified result format is used by both TEE and local processing paths.
 type AuctionResult struct {
@@ -29,15 +49,27 @@ type AuctionResult struct {
 	// EligibleBids contains all bids that passed floor enforcement and were included in ranking
 	EligibleBids []CoreBid
 
-	// PriceRejectedBidIDs contains IDs of bids rejected due to invalid prices
+	// PriceRejected identifies the bids rejected for invalid prices, by bidder.
+	PriceRejected []BidRef
+
+	// FloorRejected identifies the bids that failed floor enforcement, by bidder.
+	FloorRejected []BidRef
+
+	// Deprecated: use PriceRejected. A bare bid ID cannot be attributed to a
+	// bidder when two bidders in the round share it.
 	PriceRejectedBidIDs []string
 
-	// FloorRejectedBidIDs contains IDs of bids that failed floor enforcement
+	// Deprecated: use FloorRejected. A bare bid ID cannot be attributed to a
+	// bidder when two bidders in the round share it.
 	FloorRejectedBidIDs []string
 }
 
 // ExcludedBid represents a bid that was excluded from the auction (floor rejection, decryption failure, etc.)
 type ExcludedBid struct {
-	BidID  string `json:"bid_id"`
+	BidID string `json:"bid_id"`
+	// Bidder that submitted the bid. Empty from enclaves predating
+	// bidder-qualified exclusions, in which case callers must fall back to
+	// their own attribution.
+	Bidder string `json:"bidder,omitempty"`
 	Reason string `json:"reason"`
 }

--- a/enclave/auction.go
+++ b/enclave/auction.go
@@ -106,6 +106,8 @@ func ProcessAuction(attester EnclaveAttester, req enclaveapi.EnclaveAuctionReque
 		AttestationCOSEBase64: coseAttestation.EncodeBase64(),
 		ExcludedBids:          excludedBids,
 		FloorRejectedBidIDs:   floorRejectedBidIDs,
+		WinnerBidder:          bidderOf(winner),
+		RunnerUpBidder:        bidderOf(runnerUp),
 		ProcessingTime:        processingTime,
 		AttestationUs:         attestationUs,
 	}
@@ -114,6 +116,14 @@ func ProcessAuction(attester EnclaveAttester, req enclaveapi.EnclaveAuctionReque
 func getBidderName(bid *core.CoreBid) string {
 	if bid == nil {
 		return "none"
+	}
+	return bid.Bidder
+}
+
+// bidderOf returns the bid's bidder, or "" for a nil bid.
+func bidderOf(bid *core.CoreBid) string {
+	if bid == nil {
+		return ""
 	}
 	return bid.Bidder
 }

--- a/enclave/auction.go
+++ b/enclave/auction.go
@@ -105,7 +105,7 @@ func ProcessAuction(attester EnclaveAttester, req enclaveapi.EnclaveAuctionReque
 		ExcludedBids:          excludedBids,
 		FloorRejected:         auctionResult.FloorRejected,
 		PriceRejected:         auctionResult.PriceRejected,
-		FloorRejectedBidIDs:   auctionResult.FloorRejectedBidIDs,
+		FloorRejectedBidIDs:   auctionResult.FloorRejectedBidIDs, //nolint:staticcheck // still populated for hosts predating the qualified lists
 		WinnerBidder:          bidderOf(winner),
 		RunnerUpBidder:        bidderOf(runnerUp),
 		ProcessingTime:        processingTime,

--- a/enclave/auction.go
+++ b/enclave/auction.go
@@ -75,8 +75,6 @@ func ProcessAuction(attester EnclaveAttester, req enclaveapi.EnclaveAuctionReque
 	// Run unified auction logic: adjustment → floor enforcement → ranking
 	auctionResult := core.RunAuction(unencryptedBids, req.AdjustmentFactors, req.BidFloor)
 
-	floorRejectedBidIDs := auctionResult.FloorRejectedBidIDs
-
 	// Extract winner and runner-up from auction result
 	winner := auctionResult.Winner
 	runnerUp := auctionResult.RunnerUp
@@ -105,7 +103,9 @@ func ProcessAuction(attester EnclaveAttester, req enclaveapi.EnclaveAuctionReque
 		Message:               fmt.Sprintf("Processed %d bids in enclave", len(req.Bids)),
 		AttestationCOSEBase64: coseAttestation.EncodeBase64(),
 		ExcludedBids:          excludedBids,
-		FloorRejectedBidIDs:   floorRejectedBidIDs,
+		FloorRejected:         auctionResult.FloorRejected,
+		PriceRejected:         auctionResult.PriceRejected,
+		FloorRejectedBidIDs:   auctionResult.FloorRejectedBidIDs,
 		WinnerBidder:          bidderOf(winner),
 		RunnerUpBidder:        bidderOf(runnerUp),
 		ProcessingTime:        processingTime,
@@ -165,6 +165,7 @@ func decryptAllBids(encryptedBids []enclaveapi.EncryptedCoreBid, keyManager *Key
 			err := fmt.Errorf("no key manager available")
 			excludedBids = append(excludedBids, core.ExcludedBid{
 				BidID:  encBid.ID,
+				Bidder: encBid.Bidder,
 				Reason: reasonDecryptionFailed,
 			})
 			errors = append(errors, fmt.Errorf("decryption failed for bid %s: %w", encBid.ID, err))
@@ -184,6 +185,7 @@ func decryptAllBids(encryptedBids []enclaveapi.EncryptedCoreBid, keyManager *Key
 			log.Printf("INFO: Failed to decrypt bid %s: %v", encBid.ID, err)
 			excludedBids = append(excludedBids, core.ExcludedBid{
 				BidID:  encBid.ID,
+				Bidder: encBid.Bidder,
 				Reason: reasonDecryptionFailed,
 			})
 			errors = append(errors, fmt.Errorf("decryption failed for bid %s: %w", encBid.ID, err))
@@ -195,6 +197,7 @@ func decryptAllBids(encryptedBids []enclaveapi.EncryptedCoreBid, keyManager *Key
 			log.Printf("INFO: Failed to parse decrypted payload for bid %s: %v", encBid.ID, err)
 			excludedBids = append(excludedBids, core.ExcludedBid{
 				BidID:  encBid.ID,
+				Bidder: encBid.Bidder,
 				Reason: reasonInvalidPayloadFormat,
 			})
 			errors = append(errors, fmt.Errorf("invalid payload format for bid %s: %w", encBid.ID, err))
@@ -242,6 +245,7 @@ func dedupAndBuildBids(decryptedBids []decryptedBidData) ([]core.CoreBid, []core
 			log.Printf("WARNING: Bid %s decrypted but resolved to no epoch; excluding to preserve replay protection", decBid.encBid.ID)
 			excludedBids = append(excludedBids, core.ExcludedBid{
 				BidID:  decBid.encBid.ID,
+				Bidder: decBid.encBid.Bidder,
 				Reason: reasonFingerprintFailed,
 			})
 			continue
@@ -259,6 +263,7 @@ func dedupAndBuildBids(decryptedBids []decryptedBidData) ([]core.CoreBid, []core
 			log.Printf("WARNING: Failed to fingerprint bid %s: %v", decBid.encBid.ID, err)
 			excludedBids = append(excludedBids, core.ExcludedBid{
 				BidID:  decBid.encBid.ID,
+				Bidder: decBid.encBid.Bidder,
 				Reason: reasonFingerprintFailed,
 			})
 			continue
@@ -268,6 +273,7 @@ func dedupAndBuildBids(decryptedBids []decryptedBidData) ([]core.CoreBid, []core
 			log.Printf("WARNING: Bid %s excluded as duplicate ciphertext (replay)", decBid.encBid.ID)
 			excludedBids = append(excludedBids, core.ExcludedBid{
 				BidID:  decBid.encBid.ID,
+				Bidder: decBid.encBid.Bidder,
 				Reason: reasonDuplicateCiphertext,
 			})
 			continue

--- a/enclave/auction_test.go
+++ b/enclave/auction_test.go
@@ -232,6 +232,74 @@ func TestBidderOf(t *testing.T) {
 	check.Equal(t, "", bidderOf(nil))
 }
 
+// TestProcessAuction_RejectionsQualifiedByBidder: two bidders share a bid ID and
+// only one is below floor. The response must name the rejected bidder, because
+// the ID alone also belongs to the winner.
+func TestProcessAuction_RejectionsQualifiedByBidder(t *testing.T) {
+	const sharedBidID = "1"
+
+	mockAttester := CreateMockEnclave(t)
+	req := enclaveapi.EnclaveAuctionRequest{
+		Type:          "auction_request",
+		AuctionID:     "test_auction_qualified_rejections",
+		RoundIDString: "test_auction_qualified_rejections-1",
+		Bids: []enclaveapi.EncryptedCoreBid{
+			{CoreBid: core.CoreBid{ID: sharedBidID, Bidder: "aaa_bidder", Price: 2.26, Currency: "USD"}},
+			{CoreBid: core.CoreBid{ID: sharedBidID, Bidder: "zzz_bidder", Price: 0.10, Currency: "USD"}},
+			{CoreBid: core.CoreBid{ID: "2", Bidder: "mmm_bidder", Price: 0.0, Currency: "USD"}},
+		},
+		BidFloor:  1.00,
+		Timestamp: time.Now(),
+	}
+
+	response := ProcessAuction(mockAttester, req, nil)
+	assert.True(t, response.Success)
+
+	check.Equal(t, "aaa_bidder", response.WinnerBidder)
+	check.Equal(t, []core.BidRef{{BidID: sharedBidID, Bidder: "zzz_bidder"}}, response.FloorRejected)
+	check.Equal(t, []core.BidRef{{BidID: "2", Bidder: "mmm_bidder"}}, response.PriceRejected)
+
+	// The deprecated ID-only field still ships for older hosts, and on its own
+	// reports the floor rejection under the winner's bid ID.
+	check.Equal(t, []string{sharedBidID}, response.FloorRejectedBidIDs)
+}
+
+// TestProcessAuction_ExcludedBidCarriesBidder: an excluded bid names its bidder,
+// so a host never has to guess which seat lost a bid to exclusion.
+func TestProcessAuction_ExcludedBidCarriesBidder(t *testing.T) {
+	mockAttester := CreateMockEnclave(t)
+	keyManager := newTestKeyManager(t)
+
+	bid := encryptPriceBid(t, keyManager, "1", "zzz_bidder", `{"price": 3.00}`)
+	newReq := func(id string) enclaveapi.EnclaveAuctionRequest {
+		return enclaveapi.EnclaveAuctionRequest{
+			Type:          "auction_request",
+			AuctionID:     id,
+			RoundIDString: id + "-1",
+			// A plaintext bid from another bidder reuses the encrypted bid's ID,
+			// so attributing the exclusion by ID alone would be ambiguous.
+			Bids: []enclaveapi.EncryptedCoreBid{
+				bid,
+				{CoreBid: core.CoreBid{ID: "1", Bidder: "aaa_bidder", Price: 1.00, Currency: "USD"}},
+			},
+			Timestamp: time.Now(),
+		}
+	}
+
+	assert.True(t, ProcessAuction(mockAttester, newReq("test_excluded_bidder_1"), keyManager).Success)
+
+	// Replaying the identical ciphertext excludes it as a duplicate.
+	response := ProcessAuction(mockAttester, newReq("test_excluded_bidder_2"), keyManager)
+
+	assert.True(t, response.Success)
+	assert.Equal(t, 1, len(response.ExcludedBids))
+	check.Equal(t, core.ExcludedBid{
+		BidID:  "1",
+		Bidder: "zzz_bidder",
+		Reason: reasonDuplicateCiphertext,
+	}, response.ExcludedBids[0])
+}
+
 func TestGetBidderName(t *testing.T) {
 	bid := &core.CoreBid{
 		ID:     "test_bid",

--- a/enclave/auction_test.go
+++ b/enclave/auction_test.go
@@ -261,6 +261,7 @@ func TestProcessAuction_RejectionsQualifiedByBidder(t *testing.T) {
 
 	// The deprecated ID-only field still ships for older hosts, and on its own
 	// reports the floor rejection under the winner's bid ID.
+	//nolint:staticcheck // asserts the deprecated field still ships for older hosts
 	check.Equal(t, []string{sharedBidID}, response.FloorRejectedBidIDs)
 }
 

--- a/enclave/auction_test.go
+++ b/enclave/auction_test.go
@@ -70,6 +70,10 @@ func TestProcessAuction_ZeroBids(t *testing.T) {
 	check.Nil(t, attestationDoc.UserData.Winner)
 	check.Nil(t, attestationDoc.UserData.RunnerUp)
 
+	// No winner/runner-up means no bidder identity to echo
+	check.Equal(t, "", response.WinnerBidder)
+	check.Equal(t, "", response.RunnerUpBidder)
+
 	// Verify empty bid hashes
 	check.Equal(t, []string{}, attestationDoc.UserData.BidHashes)
 }
@@ -100,6 +104,10 @@ func TestProcessAuction_OneBid(t *testing.T) {
 	// Verify winner details
 	check.Equal(t, "bid1", attestationDoc.UserData.Winner.ID)
 	check.Equal(t, 2.50, attestationDoc.UserData.Winner.Price)
+
+	// Winner identity is echoed on the response envelope; no runner-up to echo
+	check.Equal(t, "bidder_a", response.WinnerBidder)
+	check.Equal(t, "", response.RunnerUpBidder)
 
 	// Verify bid hashes contains single bid
 	nonce := attestationDoc.UserData.BidHashNonce
@@ -143,6 +151,10 @@ func TestProcessAuction_TwoBids(t *testing.T) {
 	// Verify runner-up is the second highest bid (bidder_a at 2.50)
 	check.Equal(t, "bid1", attestationDoc.UserData.RunnerUp.ID)
 	check.Equal(t, 2.50, attestationDoc.UserData.RunnerUp.Price)
+
+	// Both identities are echoed on the response envelope
+	check.Equal(t, "bidder_b", response.WinnerBidder)
+	check.Equal(t, "bidder_a", response.RunnerUpBidder)
 
 	// Verify bid hashes contains both bids
 	nonce := attestationDoc.UserData.BidHashNonce
@@ -193,6 +205,10 @@ func TestProcessAuction_ThreeBids(t *testing.T) {
 	check.Equal(t, "bid1", attestationDoc.UserData.RunnerUp.ID)
 	check.Equal(t, 2.50, attestationDoc.UserData.RunnerUp.Price)
 
+	// Echoed identities follow the adjusted ranking
+	check.Equal(t, "bidder_b", response.WinnerBidder)
+	check.Equal(t, "bidder_a", response.RunnerUpBidder)
+
 	// Verify bid hashes contains all three bids
 	nonce := attestationDoc.UserData.BidHashNonce
 	hash1 := core.ComputeBidHash("bid1", 2.50, nonce)
@@ -203,6 +219,17 @@ func TestProcessAuction_ThreeBids(t *testing.T) {
 	check.True(t, slices.Contains(attestationDoc.UserData.BidHashes, hash1))
 	check.True(t, slices.Contains(attestationDoc.UserData.BidHashes, hash2))
 	check.True(t, slices.Contains(attestationDoc.UserData.BidHashes, hash3))
+}
+
+func TestBidderOf(t *testing.T) {
+	bid := &core.CoreBid{
+		ID:     "test_bid",
+		Bidder: "test_bidder",
+		Price:  1.50,
+	}
+
+	check.Equal(t, "test_bidder", bidderOf(bid))
+	check.Equal(t, "", bidderOf(nil))
 }
 
 func TestGetBidderName(t *testing.T) {

--- a/enclave/auctione2ee_test.go
+++ b/enclave/auctione2ee_test.go
@@ -118,8 +118,8 @@ func TestDecryptBids_InvalidPrice(t *testing.T) {
 	// Verify the bid will be rejected later in RunAuction
 	auctionResult := core.RunAuction(finalBids, nil, 0.0)
 	assert.Nil(t, auctionResult.Winner)
-	assert.Equal(t, 1, len(auctionResult.PriceRejectedBidIDs))
-	assert.Equal(t, "bid1", auctionResult.PriceRejectedBidIDs[0])
+	assert.Equal(t, 1, len(auctionResult.PriceRejected))
+	assert.Equal(t, core.BidRef{BidID: "bid1", Bidder: "bidder1"}, auctionResult.PriceRejected[0])
 }
 
 func TestDecryptBids_NilKeyManager(t *testing.T) {

--- a/enclaveapi/types.go
+++ b/enclaveapi/types.go
@@ -154,10 +154,20 @@ type EnclaveAuctionResponse struct {
 	Message               string                `json:"message"`
 	AttestationCOSEBase64 AttestationCOSEBase64 `json:"attestation_cose_base64,omitempty"` // Base64-encoded COSE_Sign1 attestation
 	ExcludedBids          []core.ExcludedBid    `json:"excluded_bids,omitempty"`           // Decryption failures, validation errors
-	FloorRejectedBidIDs   []string              `json:"floor_rejected_bid_ids,omitempty"`  // Bid IDs that were below floor
+	// Pre-auction rejections, identified by bidder as well as bid ID. A bare bid
+	// ID cannot be attributed to a seat: IDs are only unique per bidder, so when
+	// two bidders in a round share one, a host reconstructing the seat from the ID
+	// can route the rejection — and its loss notice — to the wrong bidder, or drop
+	// the wrong bid from its response.
+	FloorRejected []core.BidRef `json:"floor_rejected,omitempty"` // Bids below floor
+	PriceRejected []core.BidRef `json:"price_rejected,omitempty"` // Bids with non-positive prices
+	// Deprecated: use FloorRejected. Retained so hosts predating bidder-qualified
+	// rejections keep working against a newer enclave.
+	FloorRejectedBidIDs []string `json:"floor_rejected_bid_ids,omitempty"`
 	// Bidder behind the attested winner and runner-up, echoed from the request bids
 	// (bid IDs are only unique per bidder). Deliberately not part of the signed
-	// attestation user data, which is shared with SDKs and bidders and stays bidder-free.
+	// attestation user data, which is transmitted to devices and to bidders and
+	// stays bidder-free.
 	WinnerBidder   string `json:"winner_bidder,omitempty"`
 	RunnerUpBidder string `json:"runner_up_bidder,omitempty"`
 	ProcessingTime int64  `json:"processing_time_ms"`

--- a/enclaveapi/types.go
+++ b/enclaveapi/types.go
@@ -155,7 +155,12 @@ type EnclaveAuctionResponse struct {
 	AttestationCOSEBase64 AttestationCOSEBase64 `json:"attestation_cose_base64,omitempty"` // Base64-encoded COSE_Sign1 attestation
 	ExcludedBids          []core.ExcludedBid    `json:"excluded_bids,omitempty"`           // Decryption failures, validation errors
 	FloorRejectedBidIDs   []string              `json:"floor_rejected_bid_ids,omitempty"`  // Bid IDs that were below floor
-	ProcessingTime        int64                 `json:"processing_time_ms"`
+	// Bidder behind the attested winner and runner-up, echoed from the request bids
+	// (bid IDs are only unique per bidder). Deliberately not part of the signed
+	// attestation user data, which is shared with SDKs and bidders and stays bidder-free.
+	WinnerBidder   string `json:"winner_bidder,omitempty"`
+	RunnerUpBidder string `json:"runner_up_bidder,omitempty"`
+	ProcessingTime int64  `json:"processing_time_ms"`
 	// AttestationUs is the wall-clock time spent in the attestation call, in
 	// microseconds. Reported in us (not ms) because the value is often
 	// sub-millisecond and integer-ms rounding would hide it. A pointer so that


### PR DESCRIPTION
The signed attestation deliberately carries no bidder identity: `AuctionAttestationUserData` is shared with SDKs and bidders, so the winner and runner-up are attested as `CoreBidWithoutBidder` (bid ID, price, currency, deal ID, media type only). The host then has to reconstruct which bidder each attested bid belongs to — and bid IDs are only unique per bidder, so when IDs collide across bidders in a round the reconstruction is ambiguous.

This adds `WinnerBidder` and `RunnerUpBidder` to `EnclaveAuctionResponse`, populated from the auction result. They echo the `Bidder` field the host itself supplied on the request bids, so they reveal nothing to the host that it does not already know, and they are plain envelope fields — not part of the signed COSE user data, which stays bidder-free. Only the winner and runner-up identities are echoed, never the full bid list.

Both fields are `omitempty` and additive: hosts that don't read them see an unchanged response, and hosts that do read them treat them as an unsigned hint (the attested bid ID, price, and media type remain the authoritative record).

## Testing
- `go test ./...` — the ProcessAuction ranking tests now also assert the echoed identities (including under adjustment factors, where the echo must follow the adjusted ranking).