### PR TITLE
Tag the EIF builder key pair and security group on create

### DIFF
--- a/.github/workflows/eif-build.yml
+++ b/.github/workflows/eif-build.yml
@@ -160,8 +160,13 @@ jobs:
         id: create-key
         run: |
           KEY_NAME="eif-builder-${{ github.run_id }}-${{ github.run_attempt }}"
+          # Purpose=EIF-Build is what the eif-builder-workflow IAM policy gates
+          # DeleteKeyPair on, so the cleanup step below can only ever delete a
+          # key pair this workflow created. Tag on create: a later CreateTags
+          # would leave a window where cleanup is denied.
           aws ec2 create-key-pair \
             --key-name "${KEY_NAME}" \
+            --tag-specifications 'ResourceType=key-pair,Tags=[{Key=Name,Value=eif-builder},{Key=Purpose,Value=EIF-Build}]' \
             --query 'KeyMaterial' \
             --output text > /tmp/eif-builder-key.pem
           chmod 400 /tmp/eif-builder-key.pem
@@ -191,10 +196,14 @@ jobs:
         id: security-group
         run: |
           SG_NAME="eif-builder-${{ github.run_id }}"
+          # Tagged on create for the same reason as the key pair above: the IAM
+          # policy gates DeleteSecurityGroup and the ingress rule on
+          # Purpose=EIF-Build.
           SG_ID=$(aws ec2 create-security-group \
             --group-name "${SG_NAME}" \
             --description "Temporary SG for EIF building - Run ${{ github.run_id }}" \
             --vpc-id "${{ steps.vpc-info.outputs.vpc_id }}" \
+            --tag-specifications 'ResourceType=security-group,Tags=[{Key=Name,Value=eif-builder},{Key=Purpose,Value=EIF-Build}]' \
             --query 'GroupId' \
             --output text)
 


### PR DESCRIPTION
## Summary

- Each EIF build creates three throwaway EC2 resources — an instance, an SSH key pair, and a security group that opens port 22 to the world — and deletes them in the `always()` cleanup steps. Only the instance is tagged, so the `eif-builder-workflow` IAM role has to be granted `ec2:DeleteKeyPair` and `ec2:DeleteSecurityGroup` against every resource in the account for cleanup to work.
- Tag the key pair and security group with `Purpose=EIF-Build` at create time, matching the instance. That lets the IAM policy gate the destructive calls on `ec2:ResourceTag/Purpose`, so a leaked OIDC token can only delete resources this workflow created.
- Tagging happens in the same API call as the create, not a follow-up `CreateTags`, so there is no window in which the resource exists untagged and cleanup would be denied.
- No behavior change on its own. This is the prerequisite for cloudx-io/terraform-ssp#2242, which scopes the `eif-builder-workflow` EC2 permissions to tagged resources and cannot apply until this has landed in both repos and one real EIF build has exercised the new tags. Companion PR: cloudx-io/openarbiter#13.

## Pre-merge checklist

- [x] Workflow YAML parses (`yaml.safe_load`)
- [x] Diff contains no unintended changes
- [x] Cross-repo dependency noted: merge and exercise before cloudx-io/terraform-ssp#2242 applies

## Post-deploy/apply verification

- [x] Build EIF ran on the merge commit ([run 31634327782](https://github.com/cloudx-io/openauction/actions/runs/31634327782)). Key pair creation, security group creation, instance launch, the EIF build itself, and all three cleanup steps succeeded. The run is red only because of the unrelated `Install ORAS` step, where the GitHub release download returned a 107-byte error page and `tar` rejected it — so the EIF was built but never pushed to ECR. That gap is now closed: [run 31636929484](https://github.com/cloudx-io/openauction/actions/runs/31636929484), after the ORAS install was hardened in #51, is fully green including `Push EIF to ECR` and all three cleanup steps.
- [x] That run's key pair and security group both carry `Purpose=EIF-Build` — confirmed in CloudTrail: `CreateKeyPair` (`eif-builder-31634327782-1`) and `CreateSecurityGroup` (`eif-builder-31634327782`) both sent `tagSpecificationSet` with `Name=eif-builder` and `Purpose=EIF-Build`. No `eif-builder-*` security groups or key pairs remain in us-east-1.


