### PR TITLE
Fail the EIF build immediately on a bad ORAS download

### DIFF
--- a/.github/workflows/eif-build.yml
+++ b/.github/workflows/eif-build.yml
@@ -325,8 +325,22 @@ jobs:
           # the target EIF's, so it stays amd64 even for arm64 EIF builds (which are
           # built on the remote Nitro instance). Do not switch this to arm64.
           VERSION="1.1.0"
-          curl -LO "https://github.com/oras-project/oras/releases/download/v${VERSION}/oras_${VERSION}_linux_amd64.tar.gz"
-          tar -zxf oras_${VERSION}_*.tar.gz
+          TARBALL="oras_${VERSION}_linux_amd64.tar.gz"
+          # Checksum from the release's oras_${VERSION}_checksums.txt. Update
+          # both together when bumping VERSION.
+          SHA256="e09e85323b24ccc8209a1506f142e3d481e6e809018537c6b3db979c891e6ad7"
+
+          # --fail so an HTTP error page is not silently written to the tarball
+          # (a bad download used to surface much later as "gzip: stdin: not in
+          # gzip format"), plus retries for transient release-CDN failures.
+          curl --fail --location --show-error --silent \
+            --retry 5 --retry-all-errors --retry-delay 5 \
+            --output "${TARBALL}" \
+            "https://github.com/oras-project/oras/releases/download/v${VERSION}/${TARBALL}"
+
+          echo "${SHA256}  ${TARBALL}" | sha256sum --check --strict
+
+          tar -zxf "${TARBALL}" oras
           sudo mv oras /usr/local/bin/
           oras version
 


### PR DESCRIPTION
## Summary

- The ORAS install step downloaded its tarball with `curl -LO`, which has no `--fail`, so an HTTP error page was written to the file and `curl` still exited 0. The bad download only surfaced two commands later as `gzip: stdin: not in gzip format`, failing the build after the EIF had already been built on a live Nitro instance.
- This is not hypothetical: it happened on [run 31634327782](https://github.com/cloudx-io/openauction/actions/runs/31634327782), where the download returned a 107-byte error page. The EIF was built successfully and then never pushed, so that commit has no artifact in ECR. The v1.1.0 release asset was intact the whole time — it was a transient release-CDN failure.
- Add `--fail` so a bad response fails the step immediately with a clear message, `--retry 5 --retry-all-errors` so a transient CDN failure recovers on its own, and a `sha256sum --check --strict` against the checksum published in the release's `oras_1.1.0_checksums.txt`. Extract only the `oras` binary rather than globbing the archive name.

Verified both paths locally: the pinned URL downloads 3,733,462 bytes and matches `e09e8532…6ad7`, and a deliberately bad URL now exits non-zero after retrying instead of writing a 9-byte "tarball" and exiting 0.

ORAS 1.1.0 is kept as-is. Bumping toward the current 1.3.3 is a separate change with its own testing.

## Pre-merge checklist

- [x] Workflow YAML parses (`yaml.safe_load`)
- [x] Download, checksum, and extract verified against the real release asset
- [x] Failure path verified: bad URL now exits non-zero instead of silently writing an error page
- [x] Diff contains no unintended changes

## Post-deploy/apply verification

- [x] The next EIF build installs ORAS and pushes the artifact to ECR — [run 31636929484](https://github.com/cloudx-io/openauction/actions/runs/31636929484) on the merge commit is fully green: `Install ORAS`, `Login to ECR`, `Push EIF to ECR`, all three cleanup steps, and the `Update PCR validation file` job all succeeded. This also re-pushed the artifact that the earlier failure left missing.

