### PR TITLE
eif: skip the EIF build only when the commit subject leads with the marker

### DIFF
--- a/.github/workflows/eif-build.yml
+++ b/.github/workflows/eif-build.yml
@@ -57,11 +57,15 @@ jobs:
   build-eif:
     name: Build EIF on Nitro EC2
     runs-on: ubuntu-latest
+    # The [skip-build] marker is matched with startsWith, not contains: a squash
+    # merge puts the entire PR description in the commit body, so contains also
+    # matches any PR whose description merely mentions the marker in prose. The
+    # update-pcrs commits this guard exists to ignore always lead with it.
     if: |
       (github.event_name == 'workflow_dispatch' ||
        (github.event.workflow_run.conclusion == 'success' &&
         github.event.workflow_run.head_branch == 'main' &&
-        !contains(github.event.workflow_run.head_commit.message, '[skip-build]')))
+        !startsWith(github.event.workflow_run.head_commit.message, '[skip-build]')))
     permissions:
       id-token: write
       contents: read


### PR DESCRIPTION
## Summary

- The `build-eif` job guard was `!contains(github.event.workflow_run.head_commit.message, '[skip-build]')` — a substring match over the *entire* commit message, subject and body. A squash merge puts the whole PR description in the commit body, so any PR that merely mentions the marker in prose silently suppressed its own EIF build. That is not hypothetical: #52's description explained the PCR automation and used the literal marker, so `Build EIF` skipped for `d5d5632` and neither an EIF nor a PCR set was produced for it, even though `Docker Build` had succeeded and pushed the image.
- `startsWith` restores the original intent. The `update-pcrs` commits this guard exists to ignore are generated as `[skip-build] Update PCR measurements for <sha>` and always lead with the marker, so nothing that should be skipped stops being skipped.
- No existing skip behavior regresses: across this repo's entire history every commit mentioning the marker leads with it, including the one hand-written `[skip-build] make validation script match pcrs.json format`. The same is true in `openarbiter`, which carries the identical guard and gets the identical fix in cloudx-io/openarbiter#15. No ordering dependency between the two — each repo's workflow is self-contained.

The failure mode is quiet, which is what makes it worth fixing rather than working around: the skipped `Build EIF` reports as a successful-looking run with all jobs `skipped`, so a merge can silently ship no enclave image while CI looks green.

## Pre-merge checklist

- [x] `.github/workflows/eif-build.yml` parses as YAML and the `build-eif` condition is well-formed
- [x] `mise run //:ratchet:lint` passes
- [x] Every historical use of the marker in this repo leads the subject line, so the narrower match cannot regress an intended skip
- [x] Diff contains no unintended changes — one operator plus the comment explaining why the narrower match is required
- [x] `Go` and `Ratchet` green in CI — `test`, `lint`, and `Ratchet Lint` all pass

## Post-deploy/apply verification

- [x] `Build EIF` runs rather than skipping after this merge — run `31644208668` for `5192cde0` completed **successfully** rather than skipping, and this PR's description does mention the marker in prose, so the merge was a genuine test of the fix
- [x] `update-pcrs` appends a new PCR set to `validation/pcrs.json` — entry 21 for `5192cde0`, landed as commit `3ef2e9c3`
- [x] That build is also the first EIF for the Go 1.26.5 enclave from #52, which the suppressed build never produced
- [x] The guard still skips what it should — the `Build EIF` triggered by the `[skip-build] Update PCR measurements` commit `3ef2e9c3` skipped as intended, so narrowing to `startsWith` did not break the loop-prevention this guard exists for

