### PR TITLE
Pin amazonlinux:2023 by digest for reproducible enclave image builds

### DIFF
--- a/enclave/Dockerfile
+++ b/enclave/Dockerfile
@@ -1,5 +1,5 @@
 # Enclave measurements depend on these base image bytes.
-# Tag and digest move together so the pin stays on amazonlinux:2023.
+# The digest is the pin; keep the 2023 tag beside it so refreshes stay on that major.
 FROM amazonlinux:2023@sha256:694092ae18877ed4e3cb9b643759ba95df1f12af12528fefa18f60f79d4c1568
 
 ARG ENCLAVE_MAX_WORKERS=50

--- a/enclave/Dockerfile
+++ b/enclave/Dockerfile
@@ -1,4 +1,6 @@
-FROM amazonlinux:2023
+# Enclave measurements depend on these base image bytes.
+# Tag and digest move together so the pin stays on amazonlinux:2023.
+FROM amazonlinux:2023@sha256:694092ae18877ed4e3cb9b643759ba95df1f12af12528fefa18f60f79d4c1568
 
 ARG ENCLAVE_MAX_WORKERS=50
 ENV ENCLAVE_MAX_WORKERS=${ENCLAVE_MAX_WORKERS}


### PR DESCRIPTION
## Summary

- Pin `enclave/Dockerfile` to the current `amazonlinux:2023` multi-arch OCI index digest so enclave image bytes — and therefore PCR0/PCR2 — no longer float with the tag.
- Digest `sha256:694092ae18877ed4e3cb9b643759ba95df1f12af12528fefa18f60f79d4c1568` resolved via `docker buildx imagetools inspect amazonlinux:2023` and corroborated by the Docker Hub `library/amazonlinux` tag `2023` API (`last_updated` 2026-08-04T01:30:21Z). The index contains linux/amd64 (`sha256:1ebfb6ca925dfc74dc7bf3513e970590df3af9ba3a9c039f8143e5c7212021a0`) and linux/arm64/v8 (`sha256:06a3b942e9098710053f45244d94fb20b74ecb154d21cfa19006472d67a6e3d8`); this repo builds both.
- Matching pin in cloudx-io/openarbiter#17. Merging this PR runs existing Docker Build and EIF jobs on main, which publish those artifacts.

## Pre-merge checklist

- [x] Digest resolved from registry data, not hand-copied — `docker buildx imagetools inspect amazonlinux:2023` index digest matches Docker Hub tag `2023`
- [x] Index contains linux/amd64 and linux/arm64, the architectures this repo builds
- [x] Dockerfile builds for linux/arm64 and linux/amd64 against the pin (`docker buildx build --platform linux/arm64,linux/amd64`)
- [x] Diff contains no unintended changes
- [x] PR CI green (Go + Ratchet)

## Post-deploy/apply verification

- [x] Docker Build on main succeeded for the merge commit (existing CI; publishes the enclave image) — [Docker Build #31742045929](https://github.com/cloudx-io/openauction/actions/runs/31742045929) success on `cdd2fd14`; linux/arm64 resolved `amazonlinux:2023@sha256:694092ae18877ed4e3cb9b643759ba95df1f12af12528fefa18f60f79d4c1568` and pushed.
- [x] EIF build on main succeeded (existing CI; publishes the EIF artifact) — [Build EIF #31742363250](https://github.com/cloudx-io/openauction/actions/runs/31742363250) success on `cdd2fd14`; arm64 Nitro EIF published; PCR validation file updated.
