### PR TITLE
Report enclave app internals on the ping response

### DIFF
--- a/enclave/appinfo.go
+++ b/enclave/appinfo.go
@@ -42,14 +42,21 @@ func (s *EnclaveServer) appInfo() *AppInfo {
 	var mem runtime.MemStats
 	runtime.ReadMemStats(&mem)
 
+	// Read rejected before accepted. The accept loop increments accepted first
+	// and only then, for a rejected connection, rejected; reading them in the
+	// opposite order keeps the reported accepted >= rejected even when a
+	// rejection lands between the two loads.
+	rejected := s.connsRejected.Load()
+	accepted := s.connsAccepted.Load()
+
 	return &AppInfo{
 		UptimeSeconds:      s.uptimeSeconds(),
 		Goroutines:         runtime.NumGoroutine(),
 		GCNum:              mem.NumGC,
 		GCPauseTotalMillis: roundTenths(float64(mem.PauseTotalNs) / float64(time.Millisecond)),
 		HeapAllocBytes:     mem.HeapAlloc,
-		ConnsAcceptedTotal: s.connsAccepted.Load(),
-		ConnsRejectedTotal: s.connsRejected.Load(),
+		ConnsAcceptedTotal: accepted,
+		ConnsRejectedTotal: rejected,
 		WorkersInUse:       len(s.workers),
 		WorkersMax:         cap(s.workers),
 	}

--- a/enclave/appinfo.go
+++ b/enclave/appinfo.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"math"
+	"runtime"
+	"time"
+)
+
+// AppInfo reports application internals on the ping response, alongside
+// SystemInfo's /proc view of the enclave VM. A degrading or wedged server shows
+// up here first -- goroutines growing without bound, GC pause time climbing, the
+// worker pool saturating, or an accept loop that has stopped advancing -- while
+// /proc CPU and memory can read entirely normal.
+//
+// Counters are cumulative for the life of the process, not deltas: the host-side
+// collector is stateless and rates are derived where they are queried. An
+// enclave restart therefore resets them to zero.
+type AppInfo struct {
+	UptimeSeconds float64 `json:"uptime_s"`
+
+	Goroutines         int     `json:"goroutines"`
+	GCNum              uint32  `json:"gc_num"`
+	GCPauseTotalMillis float64 `json:"gc_pause_total_ms"`
+	HeapAllocBytes     uint64  `json:"heap_alloc_bytes"`
+
+	ConnsAcceptedTotal uint64 `json:"conns_accepted_total"`
+	ConnsRejectedTotal uint64 `json:"conns_rejected_total"`
+
+	WorkersInUse int `json:"workers_in_use"`
+	WorkersMax   int `json:"workers_max"`
+}
+
+// appInfo snapshots the current application internals. Cheap enough for the ping
+// path, which every liveness probe and metrics tick traverses: atomic loads, two
+// channel length reads, and one runtime.ReadMemStats (a brief stop-the-world,
+// microseconds at this heap size and far cheaper than the CPU sample SystemInfo
+// already takes on the same request).
+//
+// WorkersInUse counts the request being served right now, so on the ping path it
+// never reads zero -- a fully idle server reports 1.
+func (s *EnclaveServer) appInfo() *AppInfo {
+	var mem runtime.MemStats
+	runtime.ReadMemStats(&mem)
+
+	return &AppInfo{
+		UptimeSeconds:      s.uptimeSeconds(),
+		Goroutines:         runtime.NumGoroutine(),
+		GCNum:              mem.NumGC,
+		GCPauseTotalMillis: roundTenths(float64(mem.PauseTotalNs) / float64(time.Millisecond)),
+		HeapAllocBytes:     mem.HeapAlloc,
+		ConnsAcceptedTotal: s.connsAccepted.Load(),
+		ConnsRejectedTotal: s.connsRejected.Load(),
+		WorkersInUse:       len(s.workers),
+		WorkersMax:         cap(s.workers),
+	}
+}
+
+// uptimeSeconds reports how long the server has been running. A zero startTime
+// means the server was built without NewEnclaveServer, so report 0 rather than
+// seconds since the zero time.
+func (s *EnclaveServer) uptimeSeconds() float64 {
+	if s.startTime.IsZero() {
+		return 0
+	}
+	return roundTenths(time.Since(s.startTime).Seconds())
+}
+
+func roundTenths(v float64) float64 {
+	return math.Round(v*10) / 10
+}

--- a/enclave/appinfo_test.go
+++ b/enclave/appinfo_test.go
@@ -40,10 +40,11 @@ func TestAppInfo_ReportsRuntimeInternals(t *testing.T) {
 
 	assert.True(t, info.Goroutines >= 1)
 	assert.True(t, info.HeapAllocBytes > 0)
-	// A short test binary may never GC; once it has, the cumulative pause time
-	// must be reported alongside the count.
-	if info.GCNum > 0 {
-		assert.True(t, info.GCPauseTotalMillis > 0)
+	// Pause time is rounded to tenths, so a few sub-50us pauses still report 0.0
+	// after a GC. The guaranteed direction is the reverse: reported pause time
+	// means collections happened.
+	if info.GCPauseTotalMillis > 0 {
+		assert.True(t, info.GCNum > 0)
 	}
 }
 

--- a/enclave/appinfo_test.go
+++ b/enclave/appinfo_test.go
@@ -1,0 +1,146 @@
+package main
+
+import (
+	"encoding/json"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/peterldowns/testy/assert"
+)
+
+// testServer builds a server with a worker pool of the given size, bypassing
+// Start (which needs a real vsock listener).
+func testServer(t *testing.T, maxWorkers int) *EnclaveServer {
+	t.Helper()
+	s := NewEnclaveServer(5000)
+	s.workers = make(chan struct{}, maxWorkers)
+	return s
+}
+
+func TestAppInfo_ReportsPoolOccupancyAndCounters(t *testing.T) {
+	s := testServer(t, 4)
+	s.workers <- struct{}{}
+	s.workers <- struct{}{}
+	s.connsAccepted.Add(7)
+	s.connsRejected.Add(2)
+
+	info := s.appInfo()
+
+	assert.Equal(t, 4, info.WorkersMax)
+	assert.Equal(t, 2, info.WorkersInUse)
+	assert.Equal(t, uint64(7), info.ConnsAcceptedTotal)
+	assert.Equal(t, uint64(2), info.ConnsRejectedTotal)
+}
+
+func TestAppInfo_ReportsRuntimeInternals(t *testing.T) {
+	s := testServer(t, 1)
+
+	info := s.appInfo()
+
+	assert.True(t, info.Goroutines >= 1)
+	assert.True(t, info.HeapAllocBytes > 0)
+	assert.True(t, info.GCPauseTotalMillis >= 0)
+}
+
+func TestAppInfo_UptimeMeasuredFromStartTime(t *testing.T) {
+	s := testServer(t, 1)
+	s.startTime = time.Now().Add(-90 * time.Second)
+
+	assert.True(t, s.appInfo().UptimeSeconds >= 90)
+}
+
+// A server built without NewEnclaveServer has a zero startTime; uptime must read
+// 0 rather than the seconds elapsed since the zero time.
+func TestAppInfo_ZeroStartTimeReportsZeroUptime(t *testing.T) {
+	s := &EnclaveServer{}
+
+	assert.Equal(t, 0.0, s.appInfo().UptimeSeconds)
+}
+
+// appInfo is reachable before Start sizes the pool, so a nil channel must report
+// an empty pool instead of panicking.
+func TestAppInfo_NilWorkerPoolReportsZeroes(t *testing.T) {
+	s := NewEnclaveServer(5000)
+
+	info := s.appInfo()
+
+	assert.Equal(t, 0, info.WorkersMax)
+	assert.Equal(t, 0, info.WorkersInUse)
+}
+
+// pongPayload mirrors how the host-side bridge decodes a pong: the blocks it
+// reads, and nothing else.
+type pongPayload struct {
+	Type   string      `json:"type"`
+	System *SystemInfo `json:"system"`
+	App    *AppInfo    `json:"app"`
+}
+
+// The pong payload is the wire contract the host-side bridge parses, so assert
+// on the serialized JSON rather than the in-process struct.
+func TestPingResponse_CarriesSystemAndAppBlocks(t *testing.T) {
+	s := testServer(t, 8)
+	s.connsAccepted.Add(3)
+
+	raw, err := json.Marshal(s.pingResponse())
+	assert.NoError(t, err)
+
+	var pong pongPayload
+	assert.NoError(t, json.Unmarshal(raw, &pong))
+
+	assert.Equal(t, "pong", pong.Type)
+	assert.NotNil(t, pong.App)
+	assert.Equal(t, 8, pong.App.WorkersMax)
+	assert.Equal(t, uint64(3), pong.App.ConnsAcceptedTotal)
+	// system is collected from /proc and may be absent off Linux; when present it
+	// must still carry the fields the bridge reads.
+	if pong.System != nil {
+		assert.True(t, pong.System.MemTotalBytes > 0)
+	}
+}
+
+func TestDispatch_RejectsAndClosesWhenPoolFull(t *testing.T) {
+	s := testServer(t, 1)
+	s.workers <- struct{}{}
+
+	conn, peer := net.Pipe()
+	t.Cleanup(func() { _ = peer.Close() })
+
+	s.dispatch(conn)
+
+	assert.Equal(t, uint64(1), s.connsRejected.Load())
+	// A rejected connection is closed before dispatch returns, so any further
+	// write must fail.
+	_, err := conn.Write([]byte("x"))
+	assert.Error(t, err)
+}
+
+func TestDispatch_AcceptsWhenPoolHasRoom(t *testing.T) {
+	s := testServer(t, 1)
+
+	conn, peer := net.Pipe()
+	// Closing the peer ends the worker's read-until-EOF so it does not outlive
+	// the test.
+	assert.NoError(t, peer.Close())
+
+	s.dispatch(conn)
+
+	assert.Equal(t, uint64(0), s.connsRejected.Load())
+}
+
+func TestRoundTenths(t *testing.T) {
+	tests := []struct {
+		in   float64
+		want float64
+	}{
+		{0, 0},
+		{1.24, 1.2},
+		{1.25, 1.3},
+		{90.06, 90.1},
+	}
+
+	for _, tt := range tests {
+		assert.Equal(t, tt.want, roundTenths(tt.in))
+	}
+}

--- a/enclave/appinfo_test.go
+++ b/enclave/appinfo_test.go
@@ -40,7 +40,11 @@ func TestAppInfo_ReportsRuntimeInternals(t *testing.T) {
 
 	assert.True(t, info.Goroutines >= 1)
 	assert.True(t, info.HeapAllocBytes > 0)
-	assert.True(t, info.GCPauseTotalMillis >= 0)
+	// A short test binary may never GC; once it has, the cumulative pause time
+	// must be reported alongside the count.
+	if info.GCNum > 0 {
+		assert.True(t, info.GCPauseTotalMillis > 0)
+	}
 }
 
 func TestAppInfo_UptimeMeasuredFromStartTime(t *testing.T) {

--- a/enclave/server.go
+++ b/enclave/server.go
@@ -87,7 +87,6 @@ func (s *EnclaveServer) Start() error {
 // dispatch hands an accepted connection to a worker, or closes it immediately
 // when the pool is full.
 func (s *EnclaveServer) dispatch(conn net.Conn) {
-	// Acquire worker slot - immediate rejection if pool full
 	select {
 	case s.workers <- struct{}{}:
 		go func() {

--- a/enclave/server.go
+++ b/enclave/server.go
@@ -69,7 +69,7 @@ func (s *EnclaveServer) Start() error {
 	if err != nil {
 		return fmt.Errorf("failed to get max workers config: %w", err)
 	}
-	semaphore := make(chan struct{}, maxWorkers)
+	s.workers = make(chan struct{}, maxWorkers)
 
 	log.Printf("INFO: Worker pool initialized with %d max concurrent workers", maxWorkers)
 
@@ -79,19 +79,26 @@ func (s *EnclaveServer) Start() error {
 			log.Printf("ERROR: Failed to accept vsock connection: %v", err)
 			continue
 		}
+		s.connsAccepted.Add(1)
+		s.dispatch(conn)
+	}
+}
 
-		// Acquire worker slot - immediate rejection if pool full
-		select {
-		case semaphore <- struct{}{}:
-			go func(c net.Conn) {
-				defer func() { <-semaphore }() // Release worker slot
-				s.handleConnection(c)
-			}(conn)
-		default:
-			log.Printf("INFO: No workers available, rejecting connection (pool full)")
-			if err := conn.Close(); err != nil {
-				log.Printf("ERROR: Failed to close rejected connection: %v", err)
-			}
+// dispatch hands an accepted connection to a worker, or closes it immediately
+// when the pool is full.
+func (s *EnclaveServer) dispatch(conn net.Conn) {
+	// Acquire worker slot - immediate rejection if pool full
+	select {
+	case s.workers <- struct{}{}:
+		go func() {
+			defer func() { <-s.workers }() // Release worker slot
+			s.handleConnection(conn)
+		}()
+	default:
+		s.connsRejected.Add(1)
+		log.Printf("INFO: No workers available, rejecting connection (pool full)")
+		if err := conn.Close(); err != nil {
+			log.Printf("ERROR: Failed to close rejected connection: %v", err)
 		}
 	}
 }
@@ -129,12 +136,7 @@ func (s *EnclaveServer) handleConnection(conn net.Conn) {
 
 	switch baseReq.Type {
 	case "ping":
-		response = map[string]any{
-			"type":      "pong",
-			"message":   "TEE server is healthy",
-			"timestamp": time.Now().Unix(),
-			"system":    getSystemInfoOrNil(),
-		}
+		response = s.pingResponse()
 		log.Printf("INFO: Responding to ping with pong")
 
 	case "key_request":
@@ -187,6 +189,19 @@ func (s *EnclaveServer) handleConnection(conn net.Conn) {
 		log.Printf("ERROR: Failed to encode response: %v", err)
 	} else {
 		log.Printf("INFO: Successfully sent response for %s", baseReq.Type)
+	}
+}
+
+// pingResponse builds the pong payload. system carries the enclave VM's /proc
+// view and app the server's own internals; both are optional to consumers, which
+// read whichever fields they understand and ignore the rest.
+func (s *EnclaveServer) pingResponse() map[string]any {
+	return map[string]any{
+		"type":      "pong",
+		"message":   "TEE server is healthy",
+		"timestamp": time.Now().Unix(),
+		"system":    getSystemInfoOrNil(),
+		"app":       s.appInfo(),
 	}
 }
 

--- a/enclave/types.go
+++ b/enclave/types.go
@@ -1,10 +1,33 @@
 package main
 
+import (
+	"sync/atomic"
+	"time"
+)
+
 type EnclaveServer struct {
 	port       uint32
 	keyManager *KeyManager
+
+	// startTime anchors the uptime reported by appInfo.
+	startTime time.Time
+
+	// workers is the request worker pool: a buffered channel used as a
+	// semaphore, so len is the number of requests in flight and cap the
+	// ceiling. Sized in Start from ENCLAVE_MAX_WORKERS and held here so the
+	// ping response can report pool occupancy.
+	workers chan struct{}
+
+	// connsAccepted counts every connection the vsock listener returned;
+	// connsRejected counts the subset closed immediately because the worker
+	// pool was full, so rejected is always a subset of accepted. Reported
+	// cumulatively by appInfo, where an accepted count that stops advancing
+	// while the host keeps dialing means the accept loop itself is no longer
+	// turning.
+	connsAccepted atomic.Uint64
+	connsRejected atomic.Uint64
 }
 
 func NewEnclaveServer(port uint32) *EnclaveServer {
-	return &EnclaveServer{port: port}
+	return &EnclaveServer{port: port, startTime: time.Now()}
 }


### PR DESCRIPTION
## Summary

- Adds an `app` block to the enclave's `ping` response carrying application internals — uptime, goroutine count, GC count and cumulative pause time, heap alloc, cumulative accepted/rejected connection counts, and worker-pool occupancy — alongside the existing `system` block's `/proc` view.
- Motivation is enclave-freeze forensics. When an enclave wedges, `nitro-cli` still reports `State:RUNNING` and the host-side `system` CPU/memory readings stay flat right up to the cliff, so today there is no signal that distinguishes a degrading server (goroutines climbing, GC churn, worker pool saturating, accept loop no longer advancing) from a healthy one. These fields are sampled on every liveness probe and metrics tick, so they give us the minutes before a freeze rather than only the aftermath.
- Counters are cumulative for the process lifetime, not deltas: the host-side collector stays stateless and rates are derived at query time. An enclave restart resets them to zero.
- Purely additive on the wire. Existing consumers decode the fields they know and ignore `app`; the host-side bridge only starts reporting these once cloudx-io/packer-aws-ami#52 ships, and that change treats the block as optional so arbiter enclaves (which do not emit it) are unaffected.

## Deploy order

Merging this publishes a new EIF tag but changes nothing on its own. The full sequence is this PR, then cloudx-io/packer-aws-ami#52 plus a Build AMI dispatch, then an `enclave_image_tag` bump in stage so the metrics are emitted at least once, and only then cloudx-io/terraform-ssp#2313 — Datadog rejects a tag configuration for a metric it has never ingested, so that allowlist cannot apply before this ships to a live host.

## Pre-merge checklist

- [x] Build passes (`mise run //:test` compiles all packages)
- [x] Lint passes (`mise run //:lint`, 0 issues; `mise run //:tidy` clean)
- [x] Tests pass (`mise run //:test` and `mise run //:test -race`), with new coverage for the snapshot fields, the pong wire shape, and the pool-full reject path
- [x] Diff contains no unintended changes
- [x] Cross-repo dependencies noted and ordered

## Post-deploy/apply verification

- [x] Docker Build and Build EIF workflows succeed on `main` and publish the new EIF tag — EIF run 31836841973 green, ECR carries `866a911-arm64` (and the full-SHA tag) pushed 2026-08-14T20:16Z
- [x] `validation/pcrs.json` receives the PCR set for the merge commit — commit `0446ffb` recorded the PCR set for `866a911792e1b64af150993a1f4e89bff703ffb6`
