### PR TITLE
eif-build: harden against image_tag shell injection and PCR poisoning

### DIFF
--- a/.github/workflows/eif-build.yml
+++ b/.github/workflows/eif-build.yml
@@ -152,22 +152,23 @@ jobs:
           # For workflow_dispatch: use user-provided image tag
           if [ -n "${INPUT_IMAGE_TAG}" ]; then
             IMAGE_TAG="${INPUT_IMAGE_TAG}"
-            echo "Using manually specified image tag: ${IMAGE_TAG}"
           else
             IMAGE_TAG="${COMMIT_SHA}"
-            echo "Using commit-based image tag: ${IMAGE_TAG}"
           fi
 
-          # Defense in depth on top of env binding: reject anything that is not a
-          # well-formed OCI tag before it reaches the SSH command that consumes
-          # image_uri. Match the whole string with bash's =~ rather than a
-          # line-oriented grep -- grep succeeds when ANY line matches, so a
-          # multi-line tag whose first line is valid would pass while smuggling a
-          # quote/semicolon on a later line -- and cap length at the OCI limit.
+          # Validate BEFORE echoing anything derived from the tag. Defense in depth
+          # on top of env binding: reject anything that is not a well-formed OCI tag
+          # before it reaches the SSH command that consumes image_uri, or the log.
+          # Match the whole string with bash's =~ rather than a line-oriented grep
+          # (grep succeeds when ANY line matches, so a multi-line tag whose first
+          # line is valid would pass), and cap length at the OCI limit. The error
+          # deliberately does not echo the raw tag: a multi-line value could emit a
+          # ::workflow-command:: line the runner parses even though the step fails.
           if [[ ! "${IMAGE_TAG}" =~ ^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$ ]]; then
-            echo "::error::Invalid image tag (must be 1-128 chars of [A-Za-z0-9._-], not starting with . or -): ${IMAGE_TAG}"
+            echo "::error::Invalid image tag (must be 1-128 chars of [A-Za-z0-9._-], not starting with . or -)"
             exit 1
           fi
+          echo "Using image tag: ${IMAGE_TAG}"
 
           if [ "${ARCHITECTURE}" = "arm64" ] && [[ "${IMAGE_TAG}" != *-arm64 ]]; then
             IMAGE_TAG="${IMAGE_TAG}-arm64"

--- a/.github/workflows/eif-build.yml
+++ b/.github/workflows/eif-build.yml
@@ -138,25 +138,40 @@ jobs:
 
       - name: Construct Docker image URI
         id: image-uri
+        env:
+          # image_tag is an untrusted workflow_dispatch input. Bind it into the
+          # environment instead of interpolating ${{ ... }} into the script body,
+          # so a crafted tag cannot break out of the quoting and run commands on
+          # the runner (which has already assumed the eif-builder-workflow role).
+          INPUT_IMAGE_TAG: ${{ github.event.inputs.image_tag }}
+          COMMIT_SHA: ${{ steps.set-sha.outputs.commit_sha }}
+          ARCHITECTURE: ${{ steps.builder-arch.outputs.architecture }}
+          ECR_REGISTRY: ${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${{ env.AWS_REGION }}.amazonaws.com
         run: |
           # For workflow_run: use commit SHA from triggering workflow
           # For workflow_dispatch: use user-provided image tag
-          if [ -n "${{ github.event.inputs.image_tag }}" ]; then
-            IMAGE_TAG="${{ github.event.inputs.image_tag }}"
+          if [ -n "${INPUT_IMAGE_TAG}" ]; then
+            IMAGE_TAG="${INPUT_IMAGE_TAG}"
             echo "Using manually specified image tag: ${IMAGE_TAG}"
           else
-            COMMIT_SHA="${{ steps.set-sha.outputs.commit_sha }}"
             IMAGE_TAG="${COMMIT_SHA}"
             echo "Using commit-based image tag: ${IMAGE_TAG}"
           fi
 
-          ARCHITECTURE="${{ steps.builder-arch.outputs.architecture }}"
+          # Defense in depth on top of env binding: reject anything that is not a
+          # well-formed OCI tag, so no shell metacharacter can reach the SSH
+          # command that later consumes image_uri.
+          if ! printf '%s' "${IMAGE_TAG}" | grep -Eq '^[A-Za-z0-9][A-Za-z0-9._-]*$'; then
+            echo "::error::Invalid image tag (allowed characters: A-Za-z0-9._-): ${IMAGE_TAG}"
+            exit 1
+          fi
+
           if [ "${ARCHITECTURE}" = "arm64" ] && [[ "${IMAGE_TAG}" != *-arm64 ]]; then
             IMAGE_TAG="${IMAGE_TAG}-arm64"
             echo "Using arm64 image tag: ${IMAGE_TAG}"
           fi
 
-          IMAGE_URI="${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${{ env.AWS_REGION }}.amazonaws.com/cloudx-io/openauction/enclave:${IMAGE_TAG}"
+          IMAGE_URI="${ECR_REGISTRY}/cloudx-io/openauction/enclave:${IMAGE_TAG}"
           echo "image_uri=${IMAGE_URI}" >> "$GITHUB_OUTPUT"
           echo "Docker image: ${IMAGE_URI}"
 
@@ -288,14 +303,21 @@ jobs:
               'sudo bash ~/scripts/setup-nitro-instance.sh'
 
       - name: Build EIF
+        env:
+          # image_uri derives from the untrusted image_tag input, so bind it (and
+          # the instance IP) into the environment rather than interpolating
+          # ${{ ... }} into the double-quoted SSH command, where a $(...) in the
+          # value would otherwise be evaluated by the runner's shell.
+          IMAGE_URI: ${{ steps.image-uri.outputs.image_uri }}
+          PUBLIC_IP: ${{ steps.launch-instance.outputs.public_ip }}
         run: |
           ssh -i /tmp/eif-builder-key.pem \
               -o StrictHostKeyChecking=no \
-              ec2-user@${{ steps.launch-instance.outputs.public_ip }} \
+              "ec2-user@${PUBLIC_IP}" \
               "sudo bash ~/scripts/build-eif-ci.sh \
-                    '${{ steps.image-uri.outputs.image_uri }}' \
+                    '${IMAGE_URI}' \
                     '/tmp/auction.eif' \
-                    '${{ env.AWS_REGION }}'"
+                    '${AWS_REGION}'"
 
       - name: Download EIF and measurements
         run: |
@@ -453,7 +475,14 @@ jobs:
     needs: build-eif
     # arm64 is the canonical fleet, so validation/pcrs.json tracks arm64 PCRs.
     # amd64 dispatches (now opt-in) don't touch the file to avoid arch-mismatched entries.
-    if: github.ref == 'refs/heads/main' && needs.build-eif.outputs.architecture == 'arm64'
+    # image_tag overrides are barred from this path: PCRs are recorded under the
+    # checked-out commit SHA, so a dispatch that measures an arbitrary image_tag would
+    # otherwise append that image's measurements to the bidder-facing allowlist as if
+    # they belonged to main. Only auto-tagged builds (tag == commit) may update pcrs.json.
+    if: >-
+      github.ref == 'refs/heads/main' &&
+      needs.build-eif.outputs.architecture == 'arm64' &&
+      github.event.inputs.image_tag == ''
     env:
       GH_APP_CLIENT_ID: 'Iv23li0CF0SJXIuRq9kS'
 

--- a/.github/workflows/eif-build.yml
+++ b/.github/workflows/eif-build.yml
@@ -159,10 +159,13 @@ jobs:
           fi
 
           # Defense in depth on top of env binding: reject anything that is not a
-          # well-formed OCI tag, so no shell metacharacter can reach the SSH
-          # command that later consumes image_uri.
-          if ! printf '%s' "${IMAGE_TAG}" | grep -Eq '^[A-Za-z0-9][A-Za-z0-9._-]*$'; then
-            echo "::error::Invalid image tag (allowed characters: A-Za-z0-9._-): ${IMAGE_TAG}"
+          # well-formed OCI tag before it reaches the SSH command that consumes
+          # image_uri. Match the whole string with bash's =~ rather than a
+          # line-oriented grep -- grep succeeds when ANY line matches, so a
+          # multi-line tag whose first line is valid would pass while smuggling a
+          # quote/semicolon on a later line -- and cap length at the OCI limit.
+          if [[ ! "${IMAGE_TAG}" =~ ^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$ ]]; then
+            echo "::error::Invalid image tag (must be 1-128 chars of [A-Za-z0-9._-], not starting with . or -): ${IMAGE_TAG}"
             exit 1
           fi
 

--- a/.github/workflows/eif-build.yml
+++ b/.github/workflows/eif-build.yml
@@ -304,16 +304,15 @@ jobs:
 
       - name: Build EIF
         env:
-          # image_uri derives from the untrusted image_tag input, so bind it (and
-          # the instance IP) into the environment rather than interpolating
-          # ${{ ... }} into the double-quoted SSH command, where a $(...) in the
-          # value would otherwise be evaluated by the runner's shell.
+          # image_uri derives from the untrusted image_tag input, so bind it into
+          # the environment rather than interpolating ${{ ... }} into the
+          # double-quoted SSH command, where a $(...) in the value would otherwise
+          # be evaluated by the runner's shell before ssh is invoked.
           IMAGE_URI: ${{ steps.image-uri.outputs.image_uri }}
-          PUBLIC_IP: ${{ steps.launch-instance.outputs.public_ip }}
         run: |
           ssh -i /tmp/eif-builder-key.pem \
               -o StrictHostKeyChecking=no \
-              "ec2-user@${PUBLIC_IP}" \
+              ec2-user@${{ steps.launch-instance.outputs.public_ip }} \
               "sudo bash ~/scripts/build-eif-ci.sh \
                     '${IMAGE_URI}' \
                     '/tmp/auction.eif' \


### PR DESCRIPTION
## Summary

- Harden the Build EIF workflow against shell injection from the untrusted `image_tag` `workflow_dispatch` input: it was interpolated raw as `${{ github.event.inputs.image_tag }}` into the "Construct Docker image URI" bash step and, via the derived `image_uri`, into the double-quoted SSH command in "Build EIF" — so a crafted tag could run commands on the runner (which has already assumed the `eif-builder-workflow` AWS role) and on the ephemeral Nitro builder over `sudo`.
- Bind those values into the step `env:` and reference them as `$INPUT_IMAGE_TAG` / `$IMAGE_URI` so GitHub never text-substitutes the untrusted input into a script body, validate the tag as a whole string against `^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$` (bash `=~`, not a line-oriented `grep`) before it is echoed or used, and reject anything that is not a well-formed OCI tag so no shell metacharacter or `::workflow-command::` line can reach downstream steps or the log. The AWS-assigned `public_ip` stays interpolated as in the sibling SSH/SCP steps — it is not attacker-controlled, so it is treated uniformly rather than bound in this one step only.
- Bar `image_tag` overrides from the `update-pcrs` job. PCR measurements are recorded under the checked-out commit SHA regardless of which image was actually built, so a dispatch pointing `image_tag` at an arbitrary/unreviewed image could otherwise append that image's PCR0/1/2 to the bidder-facing `validation/pcrs.json` as if they belonged to main. Only auto-tagged builds (tag == commit) may now write the allowlist.
- No behavior change for the legitimate paths: the automated `workflow_run` build on main and a plain `workflow_dispatch` on main both leave `image_tag` empty, so they still update `pcrs.json` exactly as before.

## Pre-merge checklist

- [x] Workflow YAML is valid (parses; GitHub Actions `lint` + `Ratchet Lint` green)
- [x] Legit trigger paths unaffected (automated `workflow_run` on main and plain main dispatch still reach `update-pcrs`; only `image_tag`-overridden dispatches are barred)
- [x] Diff contains no unintended changes (only `.github/workflows/eif-build.yml`)
- [x] CI checks green (`lint`, `test`, `Ratchet Lint` all pass)

## Post-deploy/apply verification

No deploy/apply for this change — it is a CI workflow. The hardened Build EIF workflow next exercises on the following automated arm64 build (next merge to main) or a manual dispatch; confirm that run still builds the EIF and updates `validation/pcrs.json` as before.

