### PR TITLE
ci: publish enclave images only for pushes to this repo's default branch

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -44,22 +44,18 @@ jobs:
           # into the script body; head_branch is a free-form ref name.
           EVENT_NAME: ${{ github.event_name }}
           TRIGGER_EVENT: ${{ github.event.workflow_run.event }}
-          TRIGGER_REPOSITORY: ${{ github.event.workflow_run.head_repository.full_name }}
           TRIGGER_BRANCH: ${{ github.event.workflow_run.head_branch }}
-          REPOSITORY: ${{ github.repository }}
           REF: ${{ github.ref }}
         run: |
-          # Automated builds publish, and move `latest`, only when the triggering
-          # run was a push to this repository's default branch: the trigger event,
-          # source repository and branch are each checked. A dispatch on main
-          # publishes the same way; a non-main arm64 dispatch publishes only the
-          # commit-specific tags used for EIF validation.
+          # Automated builds publish, and move `latest`, only for a push to this
+          # repository's default branch. A push run is always on the repository's
+          # own ref, so event plus branch identify it without a repository check.
+          # A dispatch on main publishes the same way; a non-main arm64 dispatch
+          # publishes only the commit-specific tags used for EIF validation.
           PUBLISH_IMAGE=false
           TAG_LATEST=false
           if [ "${EVENT_NAME}" = "workflow_run" ]; then
-            if [ "${TRIGGER_EVENT}" = "push" ] \
-              && [ "${TRIGGER_REPOSITORY}" = "${REPOSITORY}" ] \
-              && [ "${TRIGGER_BRANCH}" = "main" ]; then
+            if [ "${TRIGGER_EVENT}" = "push" ] && [ "${TRIGGER_BRANCH}" = "main" ]; then
               PUBLISH_IMAGE=true
               TAG_LATEST=true
             fi

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -38,16 +38,41 @@ jobs:
           else
             echo "IMAGE_TAG_SUFFIX=" >> "$GITHUB_ENV"
           fi
-
+      - name: docker set publish env vars
+        env:
+          # Trigger metadata is bound into the environment rather than interpolated
+          # into the script body; head_branch is a free-form ref name.
+          EVENT_NAME: ${{ github.event_name }}
+          TRIGGER_EVENT: ${{ github.event.workflow_run.event }}
+          TRIGGER_REPOSITORY: ${{ github.event.workflow_run.head_repository.full_name }}
+          TRIGGER_BRANCH: ${{ github.event.workflow_run.head_branch }}
+          REPOSITORY: ${{ github.repository }}
+          REF: ${{ github.ref }}
+        run: |
+          # Automated builds publish, and move `latest`, only when the triggering
+          # run was a push to this repository's default branch: the trigger event,
+          # source repository and branch are each checked. A dispatch on main
+          # publishes the same way; a non-main arm64 dispatch publishes only the
+          # commit-specific tags used for EIF validation.
           PUBLISH_IMAGE=false
-          if [ "${{ github.event_name }}" = "workflow_run" ] && [ "${{ github.event.workflow_run.head_branch }}" = "main" ]; then
-            PUBLISH_IMAGE=true
-          elif [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            if [ "${{ github.ref }}" = "refs/heads/main" ] || [ "${ARCHITECTURE}" = "arm64" ]; then
+          TAG_LATEST=false
+          if [ "${EVENT_NAME}" = "workflow_run" ]; then
+            if [ "${TRIGGER_EVENT}" = "push" ] \
+              && [ "${TRIGGER_REPOSITORY}" = "${REPOSITORY}" ] \
+              && [ "${TRIGGER_BRANCH}" = "main" ]; then
+              PUBLISH_IMAGE=true
+              TAG_LATEST=true
+            fi
+          elif [ "${EVENT_NAME}" = "workflow_dispatch" ]; then
+            if [ "${REF}" = "refs/heads/main" ]; then
+              PUBLISH_IMAGE=true
+              TAG_LATEST=true
+            elif [ "${ARCHITECTURE}" = "arm64" ]; then
               PUBLISH_IMAGE=true
             fi
           fi
           echo "PUBLISH_IMAGE=${PUBLISH_IMAGE}" >> "$GITHUB_ENV"
+          echo "TAG_LATEST=${TAG_LATEST}" >> "$GITHUB_ENV"
       - name: Configure AWS credentials
         if: env.PUBLISH_IMAGE == 'true'
         uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # ratchet:aws-actions/configure-aws-credentials@v6
@@ -68,6 +93,12 @@ jobs:
           COMMIT="${SHA}${DIRTY}"
           echo "CLOUDX_VERSION=${VERSION}" >> "$GITHUB_ENV"
           echo "CLOUDX_COMMIT=${COMMIT}" >> "$GITHUB_ENV"
+          # Image tags and the revision label name the commit that was checked
+          # out and built. github.sha is not used: for a workflow_run it is the
+          # default-branch tip, which need not be the commit under build.
+          COMMIT_SHA="$(git rev-parse HEAD)"
+          echo "COMMIT_SHA=${COMMIT_SHA}" >> "$GITHUB_ENV"
+          echo "COMMIT_SHA_SHORT=${COMMIT_SHA:0:7}" >> "$GITHUB_ENV"
       - name: docker set metadata
         id: dockermetadata
         # https://github.com/docker/metadata-action
@@ -80,15 +111,16 @@ jobs:
             org.opencontainers.image.description=CloudX Nitro Enclave for secure auction processing
             org.opencontainers.image.vendor=cloudx.io
             org.opencontainers.image.source=https://github.com/cloudx-io/openauction
+            org.opencontainers.image.revision=${{ env.COMMIT_SHA }}
           tags: |
             # short sha of the commit
-            type=sha,prefix=,suffix=${{ env.IMAGE_TAG_SUFFIX }},format=short
+            type=raw,value=${{ env.COMMIT_SHA_SHORT }}${{ env.IMAGE_TAG_SUFFIX }},priority=100
             # long sha of the commit
-            type=sha,prefix=,suffix=${{ env.IMAGE_TAG_SUFFIX }},format=long
+            type=raw,value=${{ env.COMMIT_SHA }}${{ env.IMAGE_TAG_SUFFIX }},priority=100
             # our version tag, like "0.0.0-commit.ABCDEF01"
             type=raw,value=${{ env.CLOUDX_VERSION }}-commit.${{ env.CLOUDX_COMMIT }}${{ env.IMAGE_TAG_SUFFIX }}
             # "latest"
-            type=raw,value=latest${{ env.IMAGE_TAG_SUFFIX }},enable=${{ github.event.workflow_run.head_branch == 'main' || github.ref == 'refs/heads/main' }}
+            type=raw,value=latest${{ env.IMAGE_TAG_SUFFIX }},enable=${{ env.TAG_LATEST == 'true' }}
       - uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # ratchet:docker/setup-qemu-action@v4
         if: env.ARCHITECTURE == 'arm64'
       - uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # ratchet:docker/setup-buildx-action@v4

--- a/.github/workflows/eif-build.yml
+++ b/.github/workflows/eif-build.yml
@@ -57,9 +57,10 @@ jobs:
   build-eif:
     name: Build EIF on Nitro EC2
     runs-on: ubuntu-latest
-    # Automated builds run only for a successful Docker Build run on this
-    # repository's default branch: the triggering run's source repository and
-    # branch are both checked.
+    # Publication is gated in docker.yml: Docker Build pushes an image only for a
+    # push to this repository's default branch, so the image measured here can
+    # only have come from that path. A Docker Build run is always bound to this
+    # repository, so its source is not re-checked here.
     # The [skip-build] marker is matched with startsWith, not contains: a squash
     # merge puts the entire PR description in the commit body, so contains also
     # matches any PR whose description merely mentions the marker in prose. The
@@ -67,7 +68,6 @@ jobs:
     if: |
       (github.event_name == 'workflow_dispatch' ||
        (github.event.workflow_run.conclusion == 'success' &&
-        github.event.workflow_run.head_repository.full_name == github.repository &&
         github.event.workflow_run.head_branch == 'main' &&
         !startsWith(github.event.workflow_run.head_commit.message, '[skip-build]')))
     permissions:

--- a/.github/workflows/eif-build.yml
+++ b/.github/workflows/eif-build.yml
@@ -57,10 +57,11 @@ jobs:
   build-eif:
     name: Build EIF on Nitro EC2
     runs-on: ubuntu-latest
-    # Publication is gated in docker.yml: Docker Build pushes an image only for a
-    # push to this repository's default branch, so the image measured here can
-    # only have come from that path. A Docker Build run is always bound to this
-    # repository, so its source is not re-checked here.
+    # Publication is gated in docker.yml: automated Docker Build runs push an
+    # image only for a push to this repository's default branch, and every
+    # Docker Build run is bound to this repository, so the image's source is not
+    # re-checked here. Manual publication and measurement remain the
+    # workflow_dispatch paths of the two workflows.
     # The [skip-build] marker is matched with startsWith, not contains: a squash
     # merge puts the entire PR description in the commit body, so contains also
     # matches any PR whose description merely mentions the marker in prose. The

--- a/.github/workflows/eif-build.yml
+++ b/.github/workflows/eif-build.yml
@@ -57,6 +57,9 @@ jobs:
   build-eif:
     name: Build EIF on Nitro EC2
     runs-on: ubuntu-latest
+    # Automated builds run only for a successful Docker Build run on this
+    # repository's default branch: the triggering run's source repository and
+    # branch are both checked.
     # The [skip-build] marker is matched with startsWith, not contains: a squash
     # merge puts the entire PR description in the commit body, so contains also
     # matches any PR whose description merely mentions the marker in prose. The
@@ -64,6 +67,7 @@ jobs:
     if: |
       (github.event_name == 'workflow_dispatch' ||
        (github.event.workflow_run.conclusion == 'success' &&
+        github.event.workflow_run.head_repository.full_name == github.repository &&
         github.event.workflow_run.head_branch == 'main' &&
         !startsWith(github.event.workflow_run.head_commit.message, '[skip-build]')))
     permissions:


### PR DESCRIPTION
## Summary

- Docker Build publishes an image, and moves `latest`, only when the triggering Go run was a push to this repository's default branch, decided from the triggering run's event and branch. `pull_request`-triggered builds still run as build-only. The trigger metadata is bound into the step's environment rather than interpolated into the script body.
- Image tags and the `org.opencontainers.image.revision` label name the commit that was checked out and built (`git rev-parse HEAD`) instead of `github.sha`, which in a `workflow_run` context is the default-branch tip rather than the commit under build.
- Build EIF's gate is unchanged; a comment records that publication is gated in Docker Build.
- Dispatching the Go workflow on `main` no longer publishes an image. Docker Build's own `workflow_dispatch` remains the manual publish path and behaves as before.
- Each Docker Build tags only the commit it built. When two pushes to `main` land within one Docker Build of each other, the Build EIF run that looks for the later commit's image before it is published fails, and the later commit's own chain measures it.

Note: `workflow_run` workflows execute the workflow file on the default branch, so the Docker Build and Build EIF runs triggered by this PR use the current `main` definitions. The new publish decision is first exercised by the first push to `main` after merge.

## Pre-merge checklist

- [x] Lint passes (Ratchet Lint in CI; actionlint locally with no new findings)
- [x] Diff contains no unintended changes
- [x] Publish decision dry-run: the publish step's script evaluated against the trigger values of recent runs (default-branch push publishes; `pull_request` and Go `workflow_dispatch` do not; Docker Build `workflow_dispatch` outcomes unchanged)

## Post-deploy/apply verification

- [x] First push to `main` after merge: Docker Build publishes the commit, version, and `latest` tags for the pushed commit; Build EIF runs and `validation/pcrs.json` gains an entry for that commit; the follow-up `[skip-build]` commit's Build EIF is skipped. — Docker Build run 33646701599 published `32dcc03…-arm64`, `32dcc03-arm64`, `0.0.0-commit.32dcc03-arm64`, and `latest-arm64` with revision `32dcc03…`. Build EIF run 33647122922 failed in the builder setup for a cause unrelated to this change (fixed in #62); its re-run 33652605001 succeeded and `Update PCR validation file` pushed `399e0611` with the `pcrs.json` entry for `32dcc03…` (2026-09-02T16:09:38Z). That commit's Docker Build 33653240696 ran with `TRIGGER_EVENT: push`, `TRIGGER_BRANCH: main`, `PUBLISH_IMAGE=true` and published; its Build EIF 33653689531 was skipped.
- [x] Next `pull_request`-triggered Docker Build on `main`'s definition builds with the AWS credential, ECR login, and push steps skipped. — Docker Build run 33652270604, triggered by the Go run for #62's branch, evaluated `TRIGGER_EVENT: pull_request`, `TRIGGER_BRANCH: nick/eif-builder-ami-pin`, set `PUBLISH_IMAGE=false`, skipped `Configure AWS credentials` and `Login to Amazon ECR`, and completed the build without pushing.



