### PR TITLE
ci: pin the EIF builder AMI and drop the unused allocator setup

### DIFF
--- a/.github/workflows/eif-build.yml
+++ b/.github/workflows/eif-build.yml
@@ -48,6 +48,11 @@ on:
 
 env:
   AWS_REGION: us-east-1
+  # AL2023 release the builder runs on, pinned by AMI name so every EIF is
+  # measured on the OS, kernel and nitro-cli the TEE fleet image is built from.
+  # Bump it together with the fleet image. AL2023 marks each release deprecated
+  # about 90 days after publication, so the lookup includes deprecated images.
+  BUILDER_AMI_RELEASE: al2023-ami-2023.12.20260817.0-kernel-6.18
 
 concurrency:
   group: eif-build
@@ -122,17 +127,17 @@ jobs:
             INSTANCE_TYPE="c5.xlarge"
           fi
 
+          AMI_NAME="${BUILDER_AMI_RELEASE}-${AMI_ARCH}"
           AMI_ID=$(aws ec2 describe-images \
             --owners amazon \
-            --filters "Name=name,Values=al2023-ami-2023.*-${AMI_ARCH}" \
+            --include-deprecated \
+            --filters "Name=name,Values=${AMI_NAME}" \
                       "Name=state,Values=available" \
-                      "Name=root-device-type,Values=ebs" \
-                      "Name=virtualization-type,Values=hvm" \
-            --query 'sort_by(Images, &CreationDate)[-1].ImageId' \
+            --query 'Images[0].ImageId' \
             --output text)
 
           if [ -z "${AMI_ID}" ] || [ "${AMI_ID}" = "None" ]; then
-            echo "::error::Failed to resolve AL2023 ${AMI_ARCH} builder AMI"
+            echo "::error::Failed to resolve builder AMI ${AMI_NAME}"
             exit 1
           fi
 

--- a/.github/workflows/eif-build.yml
+++ b/.github/workflows/eif-build.yml
@@ -51,7 +51,8 @@ env:
   # AL2023 release the builder runs on, pinned by AMI name so every EIF is
   # measured on the OS, kernel and nitro-cli the TEE fleet image is built from.
   # Bump it together with the fleet image. AL2023 marks each release deprecated
-  # about 90 days after publication, so the lookup includes deprecated images.
+  # about 90 days after publication and the lookup excludes deprecated images,
+  # so a pin left past that point fails the build rather than running on one.
   BUILDER_AMI_RELEASE: al2023-ami-2023.12.20260817.0-kernel-6.18
 
 concurrency:
@@ -130,7 +131,6 @@ jobs:
           AMI_NAME="${BUILDER_AMI_RELEASE}-${AMI_ARCH}"
           AMI_ID=$(aws ec2 describe-images \
             --owners amazon \
-            --include-deprecated \
             --filters "Name=name,Values=${AMI_NAME}" \
                       "Name=state,Values=available" \
             --query 'Images[0].ImageId' \

--- a/enclave/scripts/setup-nitro-instance.sh
+++ b/enclave/scripts/setup-nitro-instance.sh
@@ -15,7 +15,9 @@ set -euo pipefail
 #   - AWS Nitro Enclaves CLI
 #   - Docker (if not already installed)
 #   - jq for JSON processing
-#   - Configures Nitro Enclaves allocator
+#
+# The Nitro Enclaves allocator (CPU and hugepage reservation for run-enclave)
+# is not configured: nitro-cli build-enclave needs only Docker and the CLI.
 
 log() {
     echo "[$(date '+%Y-%m-%d %H:%M:%S')] $*"
@@ -157,51 +159,6 @@ install_dependencies() {
     done
 }
 
-configure_nitro_allocator() {
-    log "Configuring Nitro Enclaves allocator..."
-    
-    # Create allocator config directory
-    sudo mkdir -p /etc/nitro_enclaves
-    
-    # Create allocator configuration
-    # Allocate memory and CPUs for enclave building
-    # These are conservative values suitable for c5.xlarge and similar instances
-    cat << 'EOF' | sudo tee /etc/nitro_enclaves/allocator.yaml > /dev/null
----
-# Enclave memory in MiB (6GB for EIF building)
-memory_mib: 6144
-
-# Number of vCPUs to allocate (2 CPUs for building)
-cpu_count: 2
-
-# CPU pool configuration
-# 0 = dedicated for enclave
-cpu_pool: 0
-EOF
-    
-    log "✓ Allocator configuration created"
-    
-    # Enable and start allocator service
-    if systemctl list-unit-files | grep -q nitro-enclaves-allocator; then
-        log "Enabling nitro-enclaves-allocator service..."
-        sudo systemctl enable nitro-enclaves-allocator.service
-        sudo systemctl start nitro-enclaves-allocator.service
-        
-        # Wait a moment for service to stabilize
-        sleep 2
-        
-        if systemctl is-active --quiet nitro-enclaves-allocator; then
-            log "✓ Nitro Enclaves allocator service running"
-        else
-            log "Warning: Allocator service not running (may need Nitro-compatible instance)"
-            log "This is normal on non-Nitro instances or in virtualized environments"
-        fi
-    else
-        log "Warning: nitro-enclaves-allocator service not found"
-        log "This is normal on non-Nitro instances"
-    fi
-}
-
 verify_setup() {
     log "Verifying setup..."
     
@@ -238,14 +195,6 @@ verify_setup() {
         all_good=false
     fi
     
-    # Check allocator config
-    if [ -f /etc/nitro_enclaves/allocator.yaml ]; then
-        log "✓ allocator.yaml configured"
-    else
-        log_error "✗ allocator.yaml not found"
-        all_good=false
-    fi
-    
     if [ "$all_good" = true ]; then
         log "========================================="
         log "✓ Setup complete!"
@@ -270,7 +219,6 @@ main() {
     install_nitro_cli
     install_docker
     install_dependencies
-    configure_nitro_allocator
     verify_setup
     
     log "========================================="


### PR DESCRIPTION
## Summary

- The EIF builder instance runs a pinned AL2023 release, `BUILDER_AMI_RELEASE` at the top of `.github/workflows/eif-build.yml`, resolved by exact AMI name for the requested architecture. It is the release the TEE fleet image is built from, so every enclave image file is measured on the same OS, kernel and nitro-cli the fleet runs, and a bump is one line.
- The lookup excludes deprecated images. AL2023 deprecates each release about 90 days after publication, so a pin left past that fails the build rather than running on a deprecated image.
- The builder setup script no longer writes a Nitro Enclaves allocator configuration or starts the allocator service. `nitro-cli build-enclave` needs only Docker and the CLI; the allocator reserves CPUs and hugepages for `run-enclave`, which the builder never does.

`workflow_run` workflows execute the workflow file on the default branch, so this PR's own Build EIF run uses the current `main` definition. The pin is first exercised by the first push to `main` after merge.

## Pre-merge checklist

- [x] Lint passes (Ratchet Lint in CI; actionlint locally with no new findings; shellcheck clean on the setup script) — CI `Ratchet Lint`, `lint`, and `test` pass on `e2eead7`; actionlint reports only the three pre-existing style findings in untouched steps; shellcheck on the setup script reports only the pre-existing informational note about sourcing `/etc/os-release`.
- [x] Diff contains no unintended changes — two files, 13 insertions / 60 deletions: the pin, its lookup, and the error message in `.github/workflows/eif-build.yml`; the allocator function, its call, and its verification check removed from `enclave/scripts/setup-nitro-instance.sh`.
- [x] Pinned release resolves to exactly one non-deprecated image per architecture in us-east-1 — `describe-images --owners amazon` without `--include-deprecated`: arm64 `ami-0cded71ff6ab7f608`, x86_64 `ami-0332d564d76dbd8d6`, one image each, `DeprecationTime` 2026-11-10. Checked 2026-09-02T16:00Z.

## Post-deploy/apply verification

- [x] First push to `main` after merge: Build EIF logs `Using arm64 builder c7g.xlarge with AMI <id>` for the pinned release, `Setup Nitro instance` completes without allocator steps, the EIF is pushed and `validation/pcrs.json` gains that commit's entry, and the follow-up `[skip-build]` commit's Build EIF is skipped. — Merge commit `e67f93a`: Docker Build run 33653863476 published all four tags; Build EIF run 33654252504 logged `Using arm64 builder c7g.xlarge with AMI ami-0cded71ff6ab7f608`, `Setup Nitro instance` completed with no allocator configuration or service start, `Build EIF`, `Extract PCRs`, and `Push EIF to ECR` succeeded, and `Update PCR validation file` pushed `c802f83d` (`pcrs.json` entry for `e67f93af…`, 2026-09-02T16:25:53Z). That commit's Docker Build 33654931706 published and its Build EIF 33655374591 was skipped.


