### PR TITLE
Make the update-pcrs job idempotent and race-safe

### DIFF
--- a/.github/workflows/eif-build.yml
+++ b/.github/workflows/eif-build.yml
@@ -529,28 +529,43 @@ jobs:
           # checkout above is main as of trigger time, not job start, so a
           # sibling run's PCR commit can already sit on origin. Every attempt
           # therefore starts from a fresh origin/main: skip when the built set
-          # is recorded there, otherwise append and push. A push that loses the
-          # race is retried once from the moved tip. Regenerating the commit
-          # replaces a rebase, which conflicts when both commits append to the
-          # same array tail.
+          # is recorded there, fail when the commit is recorded with different
+          # measurements (the build is not reproducible and the EIF just pushed
+          # under that commit's tag differs from the trusted one), otherwise
+          # append and push. A push that loses the race is retried once from
+          # the moved tip. Regenerating the commit replaces a rebase, which
+          # conflicts when both commits append to the same array tail.
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
           for attempt in 1 2; do
-            git fetch origin main
+            git fetch origin +refs/heads/main:refs/remotes/origin/main
             git reset --hard origin/main
 
-            recorded=$(jq -r --arg sha "${COMMIT_SHA}" \
-                             --arg pcr0 "${PCR0}" --arg pcr1 "${PCR1}" --arg pcr2 "${PCR2}" '
-              [ .pcr_sets[] | select(.commit_sha == $sha)
-                | "an entry for commit \(.commit_sha)" ]
-              + [ .pcr_sets[] | select(.pcr0 == $pcr0 and .pcr1 == $pcr1 and .pcr2 == $pcr2)
-                | "identical measurements under commit \(.commit_sha)" ]
-              | .[0] // empty' validation/pcrs.json)
-            if [ -n "${recorded}" ]; then
-              echo "::notice::validation/pcrs.json on origin/main already has ${recorded}; skipping commit and push for ${COMMIT_SHA}"
-              exit 0
-            fi
+            verdict=$(jq -r --arg sha "${COMMIT_SHA}" \
+                            --arg pcr0 "${PCR0}" --arg pcr1 "${PCR1}" --arg pcr2 "${PCR2}" '
+              def same_pcrs: .pcr0 == $pcr0 and .pcr1 == $pcr1 and .pcr2 == $pcr2;
+              (.pcr_sets | map(select(.commit_sha == $sha))) as $same_sha
+              | (.pcr_sets | map(select(same_pcrs))) as $twins
+              | if ($same_sha | any(same_pcrs)) then "skip:an entry for commit \($sha)"
+                elif ($same_sha | length) > 0 then "conflict:\($same_sha[0].pcr0)"
+                elif ($twins | length) > 0 then "skip:identical measurements under commit \($twins[0].commit_sha)"
+                else "append" end' validation/pcrs.json)
+            case "${verdict}" in
+              append) ;;
+              skip:*)
+                echo "::notice::validation/pcrs.json on origin/main already has ${verdict#skip:}; skipping commit and push for ${COMMIT_SHA}"
+                exit 0
+                ;;
+              conflict:*)
+                echo "::error::validation/pcrs.json on origin/main records commit ${COMMIT_SHA} with PCR0 ${verdict#conflict:}, but this build measured PCR0 ${PCR0}; the build is not reproducible, so the file was left unchanged"
+                exit 1
+                ;;
+              *)
+                echo "::error::unexpected verdict '${verdict}' from validation/pcrs.json"
+                exit 1
+                ;;
+            esac
 
             jq --arg sha "${COMMIT_SHA}" \
                --arg ts "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \

--- a/.github/workflows/eif-build.yml
+++ b/.github/workflows/eif-build.yml
@@ -517,27 +517,67 @@ jobs:
         with:
           token: ${{ steps.app-token.outputs.token }}
 
-      - name: Update pcrs.json
+      - name: Append PCR set and push
+        env:
+          COMMIT_SHA: ${{ needs.build-eif.outputs.commit_sha }}
+          PCR0: ${{ needs.build-eif.outputs.pcr0 }}
+          PCR1: ${{ needs.build-eif.outputs.pcr1 }}
+          PCR2: ${{ needs.build-eif.outputs.pcr2 }}
         run: |
-          # Use jq to append new PCR set
-          jq --arg sha "${{ needs.build-eif.outputs.commit_sha }}" \
-             --arg ts "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
-             --arg pcr0 "${{ needs.build-eif.outputs.pcr0 }}" \
-             --arg pcr1 "${{ needs.build-eif.outputs.pcr1 }}" \
-             --arg pcr2 "${{ needs.build-eif.outputs.pcr2 }}" \
-             '.pcr_sets += [{
-               commit_sha: $sha,
-               timestamp: $ts,
-               pcr0: $pcr0,
-               pcr1: $pcr1,
-               pcr2: $pcr2
-             }]' validation/pcrs.json > pcrs.tmp.json
-          mv pcrs.tmp.json validation/pcrs.json
-
-      - name: Commit and push
-        run: |
+          # Two runs can measure the same main commit: a push burst fires one
+          # Docker Build per merge and each one measures the tip of main. The
+          # checkout above is main as of trigger time, not job start, so a
+          # sibling run's PCR commit can already sit on origin. Every attempt
+          # therefore starts from a fresh origin/main: skip when the built set
+          # is recorded there, otherwise append and push. A push that loses the
+          # race is retried once from the moved tip. Regenerating the commit
+          # replaces a rebase, which conflicts when both commits append to the
+          # same array tail.
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add validation/pcrs.json
-          git commit -m "[skip-build] Update PCR measurements for ${{ needs.build-eif.outputs.commit_sha }}"
-          git push
+
+          for attempt in 1 2; do
+            git fetch origin main
+            git reset --hard origin/main
+
+            recorded=$(jq -r --arg sha "${COMMIT_SHA}" \
+                             --arg pcr0 "${PCR0}" --arg pcr1 "${PCR1}" --arg pcr2 "${PCR2}" '
+              [ .pcr_sets[] | select(.commit_sha == $sha)
+                | "an entry for commit \(.commit_sha)" ]
+              + [ .pcr_sets[] | select(.pcr0 == $pcr0 and .pcr1 == $pcr1 and .pcr2 == $pcr2)
+                | "identical measurements under commit \(.commit_sha)" ]
+              | .[0] // empty' validation/pcrs.json)
+            if [ -n "${recorded}" ]; then
+              echo "::notice::validation/pcrs.json on origin/main already has ${recorded}; skipping commit and push for ${COMMIT_SHA}"
+              exit 0
+            fi
+
+            jq --arg sha "${COMMIT_SHA}" \
+               --arg ts "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+               --arg pcr0 "${PCR0}" --arg pcr1 "${PCR1}" --arg pcr2 "${PCR2}" \
+               '.pcr_sets += [{
+                 commit_sha: $sha,
+                 timestamp: $ts,
+                 pcr0: $pcr0,
+                 pcr1: $pcr1,
+                 pcr2: $pcr2
+               }]' validation/pcrs.json > pcrs.tmp.json
+            mv pcrs.tmp.json validation/pcrs.json
+            git add validation/pcrs.json
+            git commit -m "[skip-build] Update PCR measurements for ${COMMIT_SHA}"
+
+            if push_output=$(git push origin HEAD:main 2>&1); then
+              echo "${push_output}"
+              echo "Recorded PCRs for ${COMMIT_SHA} on attempt ${attempt}"
+              exit 0
+            fi
+            echo "${push_output}"
+            if ! grep -q '\[rejected\]' <<< "${push_output}"; then
+              echo "::error::git push failed for a reason other than a non-fast-forward"
+              exit 1
+            fi
+            echo "origin/main moved during attempt ${attempt}; refetching"
+          done
+
+          echo "::error::git push was rejected as non-fast-forward on both attempts"
+          exit 1

--- a/.github/workflows/eif-build.yml
+++ b/.github/workflows/eif-build.yml
@@ -548,7 +548,7 @@ jobs:
               (.pcr_sets | map(select(.commit_sha == $sha))) as $same_sha
               | (.pcr_sets | map(select(same_pcrs))) as $twins
               | if ($same_sha | any(same_pcrs)) then "skip:an entry for commit \($sha)"
-                elif ($same_sha | length) > 0 then "conflict:\($same_sha[0].pcr0)"
+                elif ($same_sha | length) > 0 then "conflict:\($same_sha[0].pcr0) \($same_sha[0].pcr1) \($same_sha[0].pcr2)"
                 elif ($twins | length) > 0 then "skip:identical measurements under commit \($twins[0].commit_sha)"
                 else "append" end' validation/pcrs.json)
             case "${verdict}" in
@@ -558,7 +558,7 @@ jobs:
                 exit 0
                 ;;
               conflict:*)
-                echo "::error::validation/pcrs.json on origin/main records commit ${COMMIT_SHA} with PCR0 ${verdict#conflict:}, but this build measured PCR0 ${PCR0}; the build is not reproducible, so the file was left unchanged"
+                echo "::error::validation/pcrs.json on origin/main records commit ${COMMIT_SHA} with PCR0/PCR1/PCR2 ${verdict#conflict:}, but this build measured ${PCR0} ${PCR1} ${PCR2}; the build is not reproducible, so the file was left unchanged"
                 exit 1
                 ;;
               *)


### PR DESCRIPTION
## Summary

- The `update-pcrs` job in Build EIF now tolerates two runs measuring the same main commit. On 2026-09-08 two merges landed a minute apart (5827a51f, then f6cbe73b). Each Go run fired a Docker Build, both Docker Builds checked out the tip of main, and so both Build EIF runs measured f6cbe73b. The concurrency group serialised them: the first recorded the PCRs in dd5bd218, the second built identical PCR0/PCR1/PCR2 and its push was rejected as non-fast-forward, so the run went red ([34249799222](https://github.com/cloudx-io/openauction/actions/runs/34249799222)). The job's checkout fetches `github.sha`, the tip of main when the run was queued, into `origin/main`, so a sibling run's PCR commit that landed while the run waited is invisible to it.
- Every attempt now starts from a freshly fetched `origin/main`. When `validation/pcrs.json` there already records the built commit with the same PCR0/PCR1/PCR2, or records identical measurements under another commit, the job logs a `::notice::` naming the existing entry and exits green without a commit. When it records the built commit with different measurements, the job fails with an `::error::` and leaves the file unchanged: the build is not reproducible, and the EIF just pushed under that commit's tag differs from the one the allowlist trusts, so a person has to look. Otherwise it appends the set, commits and pushes. A push rejected as non-fast-forward is retried once from the moved tip. Any other push failure fails the job immediately. The file stays append-only.
- Sibling change in openarbiter: cloudx-io/openarbiter#25.

## Notes for reviewers

- The retry regenerates the commit on the new tip instead of `git rebase origin/main`. Two runs that append to the same array tail conflict textually on the previous last element and the closing bracket, so a rebase would stop on the conflict rather than resolve it. Fetch, reset, re-check, re-append gives the same result as a clean rebase and also catches an entry the racing run recorded for the same commit.
- The fetch names its destination, `+refs/heads/main:refs/remotes/origin/main`, so the reset reads the tip that was just fetched whatever refspec the checkout configured.
- The three PCR values and the commit SHA move from `${{ }}` interpolation into `env`, so the script reads them as data.

## Verification

- Bare-repo simulation of the step script with two clones at a stale checkout: a run for an already recorded commit skips with the notice; a same-commit rebuild with different measurements fails red and leaves the file unchanged; a run whose push loses to a concurrent append retries once and lands; identical measurements under a new commit skip; an origin that moves before both pushes fails red with the error annotation; a non-race push failure fails without a retry. The 32 existing entries are byte-identical afterwards.
- The same simulation against a runner shaped like actions/checkout (fetch-depth 1, the trigger-time SHA fetched into `origin/main`, `checkout -B main`): the fetch moves `origin/main` to the real tip, the reset lands on the sibling commit, and the append pushes as a fast-forward while the clone stays shallow.
- actionlint reports the same finding set as main; the pre-existing SC2086/SC2129 findings are in other steps.
- Not run: the workflow itself. It runs only on main after a Docker Build, so the next merge to main is its first real exercise.

## Pre-merge checklist

- [x] Lint passes (actionlint, finding set unchanged from main)
- [x] Diff contains no unintended changes

## Post-deploy/apply verification

- [x] The next Build EIF run on main either appends its PCR set to `validation/pcrs.json` or skips with the notice, and the `Update PCR validation file` job is green. Verified on the merge commit: [run 34254949118](https://github.com/cloudx-io/openauction/actions/runs/34254949118) logged `Recorded PCRs for 31ca086deed52ccaac529c11fb8942487e95d713 on attempt 1` and pushed 981258e, which is the new last entry in `validation/pcrs.json`.

